### PR TITLE
Fix product category handling

### DIFF
--- a/src/app/fichas-tecnicas/[id]/editar/page.tsx
+++ b/src/app/fichas-tecnicas/[id]/editar/page.tsx
@@ -59,8 +59,8 @@ export default function EditarFichaTecnicaPage() {
           quantidade: ing.quantidade,
         })),
         modoPreparo: fichaOriginal.modoPreparo,
-        tempoPreparo: fichaOriginal.tempoPreparo.toString(),
-        rendimentoTotal: fichaOriginal.rendimentoTotal.toString(),
+        tempoPreparo: fichaOriginal.tempoPreparo?.toString() || '',
+        rendimentoTotal: fichaOriginal.rendimentoTotal?.toString() || '',
         unidadeRendimento: fichaOriginal.unidadeRendimento,
         observacoes: fichaOriginal.observacoes || '',
       });

--- a/src/app/fichas-tecnicas/[id]/editar/page.tsx
+++ b/src/app/fichas-tecnicas/[id]/editar/page.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-// Manipula localStorage; renderização dinâmica necessária
-export const dynamic = 'force-dynamic';
-
 import React, { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/fichas-tecnicas/[id]/editar/page.tsx
+++ b/src/app/fichas-tecnicas/[id]/editar/page.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+// Manipula localStorage; renderização dinâmica necessária
+export const dynamic = 'force-dynamic';
+
 import React, { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/fichas-tecnicas/[id]/page.tsx
+++ b/src/app/fichas-tecnicas/[id]/page.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
-import { useFichasTecnicas } from '@/lib/fichasTecnicasService';
+import {
+  useFichasTecnicas,
+  obterLabelCategoriaReceita
+} from '@/lib/fichasTecnicasService';
 import { useProdutos } from '@/lib/produtosService';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 
@@ -103,7 +106,7 @@ export default function DetalheFichaTecnicaPage() {
           
           <div>
             <h3 className="text-sm font-medium text-gray-500">Categoria</h3>
-            <p className="mt-1 text-lg font-medium text-gray-900">{ficha.categoria}</p>
+            <p className="mt-1 text-lg font-medium text-gray-900">{obterLabelCategoriaReceita(ficha.categoria)}</p>
           </div>
         </div>
         

--- a/src/app/fichas-tecnicas/[id]/page.tsx
+++ b/src/app/fichas-tecnicas/[id]/page.tsx
@@ -1,4 +1,7 @@
 'use client';
+
+// Depende de dados persistidos no navegador
+export const dynamic = 'force-dynamic';
 import React from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/fichas-tecnicas/[id]/page.tsx
+++ b/src/app/fichas-tecnicas/[id]/page.tsx
@@ -1,7 +1,4 @@
 'use client';
-
-// Depende de dados persistidos no navegador
-export const dynamic = 'force-dynamic';
 import React from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/fichas-tecnicas/nova/page.tsx
+++ b/src/app/fichas-tecnicas/nova/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/fichas-tecnicas/nova/page.tsx
+++ b/src/app/fichas-tecnicas/nova/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-export const dynamic = 'force-dynamic';
-
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/fichas-tecnicas/page.tsx
+++ b/src/app/fichas-tecnicas/page.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-// Esta página depende de dados do localStorage e não deve ser pré-renderizada
-export const dynamic = 'force-dynamic';
-
 import React from 'react';
 import Card from '@/components/ui/Card';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';

--- a/src/app/fichas-tecnicas/page.tsx
+++ b/src/app/fichas-tecnicas/page.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+// Esta página depende de dados do localStorage e não deve ser pré-renderizada
+export const dynamic = 'force-dynamic';
+
 import React from 'react';
 import Card from '@/components/ui/Card';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';

--- a/src/app/fichas-tecnicas/page.tsx
+++ b/src/app/fichas-tecnicas/page.tsx
@@ -7,7 +7,11 @@ import React from 'react';
 import Card from '@/components/ui/Card';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 import Button from '@/components/ui/Button';
-import { useFichasTecnicas, FichaTecnicaInfo } from '@/lib/fichasTecnicasService';
+import {
+  useFichasTecnicas,
+  FichaTecnicaInfo,
+  obterLabelCategoriaReceita
+} from '@/lib/fichasTecnicasService';
 import Link from 'next/link';
 
 export default function FichasTecnicasPage() {
@@ -56,7 +60,7 @@ export default function FichasTecnicasPage() {
           {fichasTecnicas.map((ficha: FichaTecnicaInfo) => (
             <TableRow key={ficha.id}>
               <TableCell className="font-medium text-gray-700">{ficha.nome}</TableCell>
-              <TableCell>{ficha.categoria}</TableCell>
+              <TableCell>{obterLabelCategoriaReceita(ficha.categoria)}</TableCell>
               <TableCell>{ficha.rendimentoTotal} {ficha.unidadeRendimento}</TableCell>
               <TableCell>{formatarPreco(ficha.custoTotal)}</TableCell>
               <TableCell>{formatarPreco(ficha.custoPorcao)}</TableCell>

--- a/src/app/fichas-tecnicas/page.tsx
+++ b/src/app/fichas-tecnicas/page.tsx
@@ -1,6 +1,4 @@
 'use client';
-// Avoid static generation since data comes from localStorage
-export const dynamic = 'force-dynamic';
 
 import React from 'react';
 import Card from '@/components/ui/Card';

--- a/src/app/fichas-tecnicas/page.tsx
+++ b/src/app/fichas-tecnicas/page.tsx
@@ -1,4 +1,6 @@
 'use client';
+// Avoid static generation since data comes from localStorage
+export const dynamic = 'force-dynamic';
 
 import React from 'react';
 import Card from '@/components/ui/Card';

--- a/src/app/fichas-tecnicas/page.tsx
+++ b/src/app/fichas-tecnicas/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import Card from '@/components/ui/Card';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';

--- a/src/app/produtos/[id]/editar/page.tsx
+++ b/src/app/produtos/[id]/editar/page.tsx
@@ -50,14 +50,14 @@ export default function EditarProdutoPage() {
         preco: produtoOriginal.preco.toString(),
         fornecedor: produtoOriginal.fornecedor,
         infoNutricional: {
-          calorias: produtoOriginal.infoNutricional?.calorias.toString() || '',
-          carboidratos: produtoOriginal.infoNutricional?.carboidratos.toString() || '',
-          proteinas: produtoOriginal.infoNutricional?.proteinas.toString() || '',
-          gordurasTotais: produtoOriginal.infoNutricional?.gordurasTotais.toString() || '',
-          gordurasSaturadas: produtoOriginal.infoNutricional?.gordurasSaturadas.toString() || '',
-          gordurasTrans: produtoOriginal.infoNutricional?.gordurasTrans.toString() || '',
-          fibras: produtoOriginal.infoNutricional?.fibras.toString() || '',
-          sodio: produtoOriginal.infoNutricional?.sodio.toString() || ''
+          calorias: produtoOriginal.infoNutricional?.calorias?.toString() || '',
+          carboidratos: produtoOriginal.infoNutricional?.carboidratos?.toString() || '',
+          proteinas: produtoOriginal.infoNutricional?.proteinas?.toString() || '',
+          gordurasTotais: produtoOriginal.infoNutricional?.gordurasTotais?.toString() || '',
+          gordurasSaturadas: produtoOriginal.infoNutricional?.gordurasSaturadas?.toString() || '',
+          gordurasTrans: produtoOriginal.infoNutricional?.gordurasTrans?.toString() || '',
+          fibras: produtoOriginal.infoNutricional?.fibras?.toString() || '',
+          sodio: produtoOriginal.infoNutricional?.sodio?.toString() || ''
         }
       });
       

--- a/src/app/produtos/[id]/editar/page.tsx
+++ b/src/app/produtos/[id]/editar/page.tsx
@@ -6,7 +6,7 @@ import Card from '@/components/ui/Card';
 import Input from '@/components/ui/Input';
 import Select from '@/components/ui/Select';
 import Button from '@/components/ui/Button';
-import { useProdutos, unidadesMedida } from '@/lib/produtosService';
+import { useProdutos, unidadesMedida, categoriasProdutos } from '@/lib/produtosService';
 
 export default function EditarProdutoPage() {
   const params = useParams();
@@ -20,6 +20,7 @@ export default function EditarProdutoPage() {
   
   const [produto, setProduto] = useState({
     nome: '',
+    categoria: '',
     marca: '',
     unidadeMedida: '',
     preco: '',
@@ -43,6 +44,7 @@ export default function EditarProdutoPage() {
     if (produtoOriginal) {
       setProduto({
         nome: produtoOriginal.nome,
+        categoria: produtoOriginal.categoria || '',
         marca: produtoOriginal.marca || '',
         unidadeMedida: produtoOriginal.unidadeMedida,
         preco: produtoOriginal.preco.toString(),
@@ -93,6 +95,7 @@ export default function EditarProdutoPage() {
     const novosErros: Record<string, string> = {};
     
     if (!produto.nome) novosErros.nome = 'Nome é obrigatório';
+    if (!produto.categoria) novosErros.categoria = 'Categoria é obrigatória';
     if (!produto.unidadeMedida) novosErros.unidadeMedida = 'Unidade de medida é obrigatória';
     if (!produto.preco) novosErros.preco = 'Preço é obrigatório';
     else if (isNaN(Number(produto.preco)) || Number(produto.preco) <= 0) 
@@ -172,7 +175,7 @@ export default function EditarProdutoPage() {
       <form onSubmit={handleSubmit}>
         <Card>
           <div className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               <Input
                 label="Nome do Produto *"
                 name="nome"
@@ -181,7 +184,16 @@ export default function EditarProdutoPage() {
                 error={erros.nome}
                 placeholder="Ex: Farinha de Trigo"
               />
-              
+
+              <Select
+                label="Categoria *"
+                name="categoria"
+                value={produto.categoria}
+                onChange={handleChange}
+                options={categoriasProdutos}
+                error={erros.categoria}
+              />
+
               <Input
                 label="Marca"
                 name="marca"

--- a/src/app/produtos/[id]/editar/page.tsx
+++ b/src/app/produtos/[id]/editar/page.tsx
@@ -50,7 +50,7 @@ export default function EditarProdutoPage() {
         categoria: produtoOriginal.categoria || '',
         marca: produtoOriginal.marca || '',
         unidadeMedida: produtoOriginal.unidadeMedida,
-        preco: produtoOriginal.preco.toString(),
+        preco: produtoOriginal.preco?.toString() || '',
         fornecedor: produtoOriginal.fornecedor,
         infoNutricional: {
           calorias: produtoOriginal.infoNutricional?.calorias?.toString() || '',

--- a/src/app/produtos/[id]/editar/page.tsx
+++ b/src/app/produtos/[id]/editar/page.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-// Utiliza localStorage, portanto deve ser dinâmico
-export const dynamic = 'force-dynamic';
-
 import React, { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/produtos/[id]/editar/page.tsx
+++ b/src/app/produtos/[id]/editar/page.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+// Utiliza localStorage, portanto deve ser dinâmico
+export const dynamic = 'force-dynamic';
+
 import React, { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/produtos/[id]/page.tsx
+++ b/src/app/produtos/[id]/page.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
-import { useProdutos } from '@/lib/produtosService';
+import { useProdutos, obterLabelCategoria } from '@/lib/produtosService';
 
 export default function DetalheProdutoPage() {
   const params = useParams();
@@ -76,7 +76,7 @@ export default function DetalheProdutoPage() {
 
             <div>
               <h3 className="text-sm font-medium text-gray-500">Categoria</h3>
-              <p className="mt-1 text-lg font-medium text-gray-900">{produto.categoria}</p>
+              <p className="mt-1 text-lg font-medium text-gray-900">{obterLabelCategoria(produto.categoria)}</p>
             </div>
 
             {produto.marca && (

--- a/src/app/produtos/[id]/page.tsx
+++ b/src/app/produtos/[id]/page.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-// Depende de dados do localStorage
-export const dynamic = 'force-dynamic';
-
 import React from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/produtos/[id]/page.tsx
+++ b/src/app/produtos/[id]/page.tsx
@@ -68,12 +68,17 @@ export default function DetalheProdutoPage() {
       
       <Card>
         <div className="space-y-6">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div>
               <h3 className="text-sm font-medium text-gray-500">Nome do Produto</h3>
               <p className="mt-1 text-lg font-medium text-gray-900">{produto.nome}</p>
             </div>
-            
+
+            <div>
+              <h3 className="text-sm font-medium text-gray-500">Categoria</h3>
+              <p className="mt-1 text-lg font-medium text-gray-900">{produto.categoria}</p>
+            </div>
+
             {produto.marca && (
               <div>
                 <h3 className="text-sm font-medium text-gray-500">Marca</h3>

--- a/src/app/produtos/[id]/page.tsx
+++ b/src/app/produtos/[id]/page.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+// Depende de dados do localStorage
+export const dynamic = 'force-dynamic';
+
 import React from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/produtos/novo/page.tsx
+++ b/src/app/produtos/novo/page.tsx
@@ -6,7 +6,7 @@ import Card from '@/components/ui/Card';
 import Input from '@/components/ui/Input';
 import Select from '@/components/ui/Select';
 import Button from '@/components/ui/Button';
-import { useProdutos, unidadesMedida } from '@/lib/produtosService';
+import { useProdutos, unidadesMedida, categoriasProdutos } from '@/lib/produtosService';
 import { useState } from 'react';
 
 export default function NovoProdutoPage() {
@@ -17,6 +17,7 @@ export default function NovoProdutoPage() {
   
   const [produto, setProduto] = useState({
     nome: '',
+    categoria: '',
     marca: '',
     unidadeMedida: '',
     preco: '',
@@ -59,6 +60,7 @@ export default function NovoProdutoPage() {
     const novosErros: Record<string, string> = {};
     
     if (!produto.nome) novosErros.nome = 'Nome é obrigatório';
+    if (!produto.categoria) novosErros.categoria = 'Categoria é obrigatória';
     if (!produto.unidadeMedida) novosErros.unidadeMedida = 'Unidade de medida é obrigatória';
     if (!produto.preco) novosErros.preco = 'Preço é obrigatório';
     else if (isNaN(Number(produto.preco)) || Number(produto.preco) <= 0) 
@@ -138,7 +140,7 @@ export default function NovoProdutoPage() {
       <form onSubmit={handleSubmit}>
         <Card>
           <div className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               <Input
                 label="Nome do Produto *"
                 name="nome"
@@ -147,7 +149,16 @@ export default function NovoProdutoPage() {
                 error={erros.nome}
                 placeholder="Ex: Farinha de Trigo"
               />
-              
+
+              <Select
+                label="Categoria *"
+                name="categoria"
+                value={produto.categoria}
+                onChange={handleChange}
+                options={categoriasProdutos}
+                error={erros.categoria}
+              />
+
               <Input
                 label="Marca"
                 name="marca"

--- a/src/app/produtos/novo/page.tsx
+++ b/src/app/produtos/novo/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import React from 'react';
 import { useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/produtos/novo/page.tsx
+++ b/src/app/produtos/novo/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-export const dynamic = 'force-dynamic';
-
 import React from 'react';
 import { useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';

--- a/src/app/produtos/page.tsx
+++ b/src/app/produtos/page.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-// Listagem de produtos usa localStorage, portanto precisa ser dinâmico
-export const dynamic = 'force-dynamic';
-
 import React from 'react';
 import Card from '@/components/ui/Card';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';

--- a/src/app/produtos/page.tsx
+++ b/src/app/produtos/page.tsx
@@ -1,4 +1,6 @@
 'use client';
+// Force dynamic rendering to access localStorage at runtime
+export const dynamic = 'force-dynamic';
 
 import React from 'react';
 import Card from '@/components/ui/Card';

--- a/src/app/produtos/page.tsx
+++ b/src/app/produtos/page.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+// Listagem de produtos usa localStorage, portanto precisa ser dinâmico
+export const dynamic = 'force-dynamic';
+
 import React from 'react';
 import Card from '@/components/ui/Card';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';

--- a/src/app/produtos/page.tsx
+++ b/src/app/produtos/page.tsx
@@ -1,6 +1,4 @@
 'use client';
-// Force dynamic rendering to access localStorage at runtime
-export const dynamic = 'force-dynamic';
 
 import React from 'react';
 import Card from '@/components/ui/Card';

--- a/src/app/produtos/page.tsx
+++ b/src/app/produtos/page.tsx
@@ -34,14 +34,15 @@ export default function ProdutosPage() {
       </div>
 
       <Card>
-        <Table 
-          headers={['Nome', 'Unidade', 'Preço', 'Fornecedor', 'Ações']}
+        <Table
+          headers={['Nome', 'Categoria', 'Unidade', 'Preço', 'Fornecedor', 'Ações']}
           isLoading={isLoading}
           emptyMessage="Nenhum produto cadastrado. Clique em 'Novo Produto' para adicionar."
         >
           {produtos.map((produto: ProdutoInfo) => (
             <TableRow key={produto.id}>
               <TableCell className="font-medium text-gray-700">{produto.nome}</TableCell>
+              <TableCell>{produto.categoria}</TableCell>
               <TableCell>{produto.unidadeMedida}</TableCell>
               <TableCell>{formatarPreco(produto.preco)}</TableCell>
               <TableCell>{produto.fornecedor}</TableCell>

--- a/src/app/produtos/page.tsx
+++ b/src/app/produtos/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import Card from '@/components/ui/Card';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';

--- a/src/app/produtos/page.tsx
+++ b/src/app/produtos/page.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Card from '@/components/ui/Card';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 import Button from '@/components/ui/Button';
-import { useProdutos, ProdutoInfo } from '@/lib/produtosService';
+import { useProdutos, ProdutoInfo, obterLabelCategoria } from '@/lib/produtosService';
 import Link from 'next/link';
 
 export default function ProdutosPage() {
@@ -44,7 +44,7 @@ export default function ProdutosPage() {
           {produtos.map((produto: ProdutoInfo) => (
             <TableRow key={produto.id}>
               <TableCell className="font-medium text-gray-700">{produto.nome}</TableCell>
-              <TableCell>{produto.categoria}</TableCell>
+              <TableCell>{obterLabelCategoria(produto.categoria)}</TableCell>
               <TableCell>{produto.unidadeMedida}</TableCell>
               <TableCell>{formatarPreco(produto.preco)}</TableCell>
               <TableCell>{produto.fornecedor}</TableCell>

--- a/src/lib/fichasTecnicasService.ts
+++ b/src/lib/fichasTecnicasService.ts
@@ -258,6 +258,12 @@ export const categoriasReceitas = [
   { value: 'outro', label: 'Outro' },
 ];
 
+// Obter rótulo legível da categoria de receita
+export const obterLabelCategoriaReceita = (valor: string) => {
+  const encontrada = categoriasReceitas.find(c => c.value === valor);
+  return encontrada ? encontrada.label : valor;
+};
+
 // Dados iniciais para unidades de rendimento
 export const unidadesRendimento = [
   { value: 'porcoes', label: 'Porções' },

--- a/src/lib/fichasTecnicasService.ts
+++ b/src/lib/fichasTecnicasService.ts
@@ -51,10 +51,18 @@ const salvarFichasTecnicas = (fichas: FichaTecnicaInfo[]) => {
   localStorage.setItem('fichasTecnicas', JSON.stringify(fichas));
 };
 
-// Função para obter fichas técnicas do localStorage
+// Função para obter fichas técnicas do localStorage com fallback
 const obterFichasTecnicas = (): FichaTecnicaInfo[] => {
-  const fichasString = localStorage.getItem('fichasTecnicas');
-  return fichasString ? JSON.parse(fichasString) : [];
+  if (typeof window === 'undefined') return [];
+
+  try {
+    const fichasString = localStorage.getItem('fichasTecnicas');
+    const armazenadas = fichasString ? JSON.parse(fichasString) : [];
+    return Array.isArray(armazenadas) ? armazenadas : [];
+  } catch (error) {
+    console.error('Erro ao ler fichas técnicas do localStorage', error);
+    return [];
+  }
 };
 
 // Hook para gerenciar fichas técnicas

--- a/src/lib/fichasTecnicasService.ts
+++ b/src/lib/fichasTecnicasService.ts
@@ -260,6 +260,7 @@ export const categoriasReceitas = [
 
 // Obter rótulo legível da categoria de receita
 export const obterLabelCategoriaReceita = (valor: string) => {
+  if (!valor) return 'Não informado';
   const encontrada = categoriasReceitas.find(c => c.value === valor);
   return encontrada ? encontrada.label : valor;
 };

--- a/src/lib/fichasTecnicasService.ts
+++ b/src/lib/fichasTecnicasService.ts
@@ -134,15 +134,17 @@ export const useFichasTecnicas = () => {
     });
 
     // Calcular valores por porção
+    const divisor = rendimentoTotal > 0 ? rendimentoTotal : 1;
+
     const infoPorcao: InfoNutricionalFicha = {
-      calorias: infoTotal.calorias / rendimentoTotal,
-      carboidratos: infoTotal.carboidratos / rendimentoTotal,
-      proteinas: infoTotal.proteinas / rendimentoTotal,
-      gordurasTotais: infoTotal.gordurasTotais / rendimentoTotal,
-      gordurasSaturadas: infoTotal.gordurasSaturadas / rendimentoTotal,
-      gordurasTrans: infoTotal.gordurasTrans / rendimentoTotal,
-      fibras: infoTotal.fibras / rendimentoTotal,
-      sodio: infoTotal.sodio / rendimentoTotal
+      calorias: infoTotal.calorias / divisor,
+      carboidratos: infoTotal.carboidratos / divisor,
+      proteinas: infoTotal.proteinas / divisor,
+      gordurasTotais: infoTotal.gordurasTotais / divisor,
+      gordurasSaturadas: infoTotal.gordurasSaturadas / divisor,
+      gordurasTrans: infoTotal.gordurasTrans / divisor,
+      fibras: infoTotal.fibras / divisor,
+      sodio: infoTotal.sodio / divisor
     };
 
     return { infoTotal, infoPorcao };
@@ -157,7 +159,9 @@ export const useFichasTecnicas = () => {
     const custoTotal = ingredientesComCusto.reduce((total, ingrediente) => total + ingrediente.custo, 0);
     
     // Calcular custo por porção
-    const custoPorcao = custoTotal / ficha.rendimentoTotal;
+    const custoPorcao = ficha.rendimentoTotal > 0
+      ? custoTotal / ficha.rendimentoTotal
+      : 0;
     
     // Calcular informações nutricionais
     const { infoTotal, infoPorcao } = calcularInfoNutricional(ingredientesComCusto, ficha.rendimentoTotal);
@@ -191,7 +195,9 @@ export const useFichasTecnicas = () => {
     const custoTotal = ingredientesComCusto.reduce((total, ingrediente) => total + ingrediente.custo, 0);
     
     // Calcular custo por porção
-    const custoPorcao = custoTotal / ficha.rendimentoTotal;
+    const custoPorcao = ficha.rendimentoTotal > 0
+      ? custoTotal / ficha.rendimentoTotal
+      : 0;
     
     // Calcular informações nutricionais
     const { infoTotal, infoPorcao } = calcularInfoNutricional(ingredientesComCusto, ficha.rendimentoTotal);

--- a/src/lib/produtosService.ts
+++ b/src/lib/produtosService.ts
@@ -42,7 +42,10 @@ const obterProdutos = (): ProdutoInfo[] => {
     const produtosString = localStorage.getItem('produtos');
     const armazenados = produtosString ? JSON.parse(produtosString) : [];
     if (Array.isArray(armazenados)) {
-      return armazenados.map((p: any) => ({ categoria: '', ...p }));
+      return armazenados.map((p: any) => ({
+        ...p,
+        categoria: p.categoria ?? ''
+      }));
     }
   } catch (error) {
     console.error('Erro ao ler produtos do localStorage', error);

--- a/src/lib/produtosService.ts
+++ b/src/lib/produtosService.ts
@@ -141,6 +141,7 @@ export const categoriasProdutos = [
 
 // Obter rótulo legível de uma categoria pelo valor armazenado
 export const obterLabelCategoria = (valor: string) => {
+  if (!valor) return 'Não informado';
   const encontrado = categoriasProdutos.find(c => c.value === valor);
   return encontrado ? encontrado.label : valor;
 };

--- a/src/lib/produtosService.ts
+++ b/src/lib/produtosService.ts
@@ -34,11 +34,21 @@ const salvarProdutos = (produtos: ProdutoInfo[]) => {
   localStorage.setItem('produtos', JSON.stringify(produtos));
 };
 
-// Função para obter produtos do localStorage
+// Função para obter produtos do localStorage de forma segura
 const obterProdutos = (): ProdutoInfo[] => {
-  const produtosString = localStorage.getItem('produtos');
-  const armazenados = produtosString ? JSON.parse(produtosString) : [];
-  return armazenados.map((p: any) => ({ categoria: '', ...p }));
+  if (typeof window === 'undefined') return [];
+
+  try {
+    const produtosString = localStorage.getItem('produtos');
+    const armazenados = produtosString ? JSON.parse(produtosString) : [];
+    if (Array.isArray(armazenados)) {
+      return armazenados.map((p: any) => ({ categoria: '', ...p }));
+    }
+  } catch (error) {
+    console.error('Erro ao ler produtos do localStorage', error);
+  }
+
+  return [];
 };
 
 // Hook para gerenciar produtos

--- a/src/lib/produtosService.ts
+++ b/src/lib/produtosService.ts
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react';
 export interface ProdutoInfo {
   id: string;
   nome: string;
+  categoria: string;
   marca?: string;
   unidadeMedida: string;
   preco: number;
@@ -36,7 +37,8 @@ const salvarProdutos = (produtos: ProdutoInfo[]) => {
 // Função para obter produtos do localStorage
 const obterProdutos = (): ProdutoInfo[] => {
   const produtosString = localStorage.getItem('produtos');
-  return produtosString ? JSON.parse(produtosString) : [];
+  const armazenados = produtosString ? JSON.parse(produtosString) : [];
+  return armazenados.map((p: any) => ({ categoria: '', ...p }));
 };
 
 // Hook para gerenciar produtos
@@ -111,4 +113,15 @@ export const unidadesMedida = [
   { value: 'un', label: 'Unidade' },
   { value: 'cx', label: 'Caixa' },
   { value: 'pct', label: 'Pacote' },
+];
+
+// Categorias de produtos para classificacao em relatorios
+export const categoriasProdutos = [
+  { value: 'hortifruti', label: 'Hortifruti' },
+  { value: 'carnes', label: 'Carnes' },
+  { value: 'laticinios', label: 'Laticínios' },
+  { value: 'graos', label: 'Grãos e Cereais' },
+  { value: 'bebidas', label: 'Bebidas' },
+  { value: 'temperos', label: 'Temperos' },
+  { value: 'outros', label: 'Outros' },
 ];

--- a/src/lib/produtosService.ts
+++ b/src/lib/produtosService.ts
@@ -44,7 +44,20 @@ const obterProdutos = (): ProdutoInfo[] => {
     if (Array.isArray(armazenados)) {
       return armazenados.map((p: any) => ({
         ...p,
-        categoria: p.categoria ?? ''
+        categoria: p.categoria ?? '',
+        preco: Number(p.preco) || 0,
+        infoNutricional: p.infoNutricional
+          ? {
+              calorias: Number(p.infoNutricional.calorias) || 0,
+              carboidratos: Number(p.infoNutricional.carboidratos) || 0,
+              proteinas: Number(p.infoNutricional.proteinas) || 0,
+              gordurasTotais: Number(p.infoNutricional.gordurasTotais) || 0,
+              gordurasSaturadas: Number(p.infoNutricional.gordurasSaturadas) || 0,
+              gordurasTrans: Number(p.infoNutricional.gordurasTrans) || 0,
+              fibras: Number(p.infoNutricional.fibras) || 0,
+              sodio: Number(p.infoNutricional.sodio) || 0
+            }
+          : undefined
       }));
     }
   } catch (error) {

--- a/src/lib/produtosService.ts
+++ b/src/lib/produtosService.ts
@@ -135,3 +135,9 @@ export const categoriasProdutos = [
   { value: 'temperos', label: 'Temperos' },
   { value: 'outros', label: 'Outros' },
 ];
+
+// Obter rótulo legível de uma categoria pelo valor armazenado
+export const obterLabelCategoria = (valor: string) => {
+  const encontrado = categoriasProdutos.find(c => c.value === valor);
+  return encontrado ? encontrado.label : valor;
+};

--- a/src/lib/relatoriosService.ts
+++ b/src/lib/relatoriosService.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useProdutos } from './produtosService';
+import { useProdutos, obterLabelCategoria } from './produtosService';
 import { useFichasTecnicas } from './fichasTecnicasService';
 
 // Interface para dados de relatórios
@@ -98,7 +98,10 @@ export const useRelatorios = () => {
     });
     
     const distribuicaoCategoriasProdutos = Object.entries(categoriasProdutos)
-      .map(([categoria, quantidade]) => ({ categoria, quantidade }))
+      .map(([categoria, quantidade]) => ({
+        categoria: obterLabelCategoria(categoria),
+        quantidade
+      }))
       .sort((a, b) => b.quantidade - a.quantidade);
     
     // Distribuição de categorias de receitas

--- a/src/lib/relatoriosService.ts
+++ b/src/lib/relatoriosService.ts
@@ -88,7 +88,7 @@ export const useRelatorios = () => {
     // Distribuição de categorias de produtos
     const categoriasProdutos: Record<string, number> = {};
     produtos.forEach(produto => {
-      const categoria = produto.categoria;
+      const categoria = produto.categoria || 'Não informado';
       if (!categoriasProdutos[categoria]) {
         categoriasProdutos[categoria] = 0;
       }

--- a/src/lib/relatoriosService.ts
+++ b/src/lib/relatoriosService.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useProdutos } from './produtosService';
 import { useFichasTecnicas } from './fichasTecnicasService';
 

--- a/src/lib/relatoriosService.ts
+++ b/src/lib/relatoriosService.ts
@@ -1,7 +1,10 @@
 'use client';
 
 import { useProdutos, obterLabelCategoria } from './produtosService';
-import { useFichasTecnicas } from './fichasTecnicasService';
+import {
+  useFichasTecnicas,
+  obterLabelCategoriaReceita
+} from './fichasTecnicasService';
 
 // Interface para dados de relatórios
 export interface DadosRelatorio {
@@ -115,7 +118,10 @@ export const useRelatorios = () => {
     });
     
     const distribuicaoCategoriasReceitas = Object.entries(categoriasReceitas)
-      .map(([categoria, quantidade]) => ({ categoria, quantidade }))
+      .map(([categoria, quantidade]) => ({
+        categoria: obterLabelCategoriaReceita(categoria),
+        quantidade
+      }))
       .sort((a, b) => b.quantidade - a.quantidade);
     
     return {


### PR DESCRIPTION
## Summary
- add `categoria` to `ProdutoInfo`
- expose `categoriasProdutos` for forms
- include categoria field on product create/edit/detail pages
- show categoria in listing
- handle missing categories in reports

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4420946c8321b37b846f3d3de74a