### PR TITLE
Fix product edit and add unit management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+tsconfig.tsbuildinfo
+.next/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sistema de Gestão Gastronômica
+# Sistema de Controle - Fichas Técnicas
 
 Sistema completo para gestão de produtos, fichas técnicas e relatórios para estabelecimentos gastronômicos.
 
@@ -6,6 +6,15 @@ Sistema completo para gestão de produtos, fichas técnicas e relatórios para e
 
 - **Cadastro de Produtos/Insumos**: Gerenciamento de insumos com informações nutricionais
 - **Fichas Técnicas**: Criação e gestão de receitas com cálculos automáticos de custos
+- **Impressão de Fichas**: Gere uma versão pronta para imprimir das fichas técnicas
+- **Autenticação de Usuários**: Acesso ao sistema mediante login e senha
+- **Controle de Usuários**: Gerencie contas na seção de configurações
+- **Alteração de Senhas**: Atualize as senhas dos usuários a qualquer momento
+- **Controle de Estoque**: Registre compras de produtos e mantenha histórico
+- **Saídas de Estoque**: Lance baixas de produtos diretamente pelo estoque
+- **Categorias Personalizadas**: Cadastre e edite categorias de produtos nas configurações
+- **Unidades de Medida**: Gerencie siglas de unidades usadas nos produtos
+- **Relatório de Estoque**: Consulte o balanço completo de itens armazenados
 - **Relatórios e Dashboard**: Visualizações e métricas para tomada de decisão
 - **Interface Responsiva**: Acesso em qualquer dispositivo
 
@@ -33,7 +42,7 @@ Sistema completo para gestão de produtos, fichas técnicas e relatórios para e
    - Clique em "Add New..."
    - Selecione "Project"
    - Conecte sua conta GitHub se ainda não estiver conectada
-   - Selecione o repositório do Sistema de Gestão Gastronômica
+   - Selecione o repositório do Sistema de Controle - Fichas Técnicas
 
 3. **Configure o projeto**:
    - O Vercel detectará automaticamente que é um projeto Next.js

--- a/docs/deploy-vercel.md
+++ b/docs/deploy-vercel.md
@@ -1,6 +1,6 @@
 # Guia de Deploy no Vercel
 
-Este documento fornece instruções detalhadas para realizar o deploy do Sistema de Gestão Gastronômica no Vercel.
+Este documento fornece instruções detalhadas para realizar o deploy do Sistema de Controle - Fichas Técnicas no Vercel.
 
 ## Por que o Vercel?
 
@@ -32,7 +32,7 @@ Certifique-se de que seu repositório contém os seguintes arquivos de configura
 
 1. No dashboard do Vercel, clique em "Add New..." > "Project"
 2. Conecte sua conta GitHub se ainda não estiver conectada
-3. Selecione o repositório do Sistema de Gestão Gastronômica
+3. Selecione o repositório do Sistema de Controle - Fichas Técnicas
 4. O Vercel detectará automaticamente que é um projeto Next.js
 
 ### 4. Configuração do Deploy

--- a/docs/entrega-final.md
+++ b/docs/entrega-final.md
@@ -1,8 +1,8 @@
-# Entrega Final - Sistema de Gestão Gastronômica
+# Entrega Final - Sistema de Controle - Fichas Técnicas
 
 ## Resumo do Projeto
 
-O Sistema de Gestão Gastronômica foi completamente reconstruído e está pronto para uso. Este documento resume o trabalho realizado e os arquivos entregues.
+O Sistema de Controle - Fichas Técnicas foi completamente reconstruído e está pronto para uso. Este documento resume o trabalho realizado e os arquivos entregues.
 
 ## Arquivos Entregues
 
@@ -36,6 +36,13 @@ O Sistema de Gestão Gastronômica foi completamente reconstruído e está pront
    - Relatórios específicos (custos, ingredientes, receitas)
    - Análises de distribuição por categoria
    - Identificação de itens mais utilizados
+4. **Controle de Usuários**
+   - Login e logout básico
+   - Cadastro e exclusão de usuários na seção de configurações
+   - Alteração de senha diretamente no controle de usuários
+5. **Controle de Estoque**
+   - Registro de compras com atualização de preços de produtos
+   - Histórico de movimentações para acompanhar evolução de custos
 
 ## Tecnologias Utilizadas
 
@@ -69,17 +76,16 @@ O sistema está configurado para ser implantado no Vercel, conforme detalhado no
    - Implementar sincronização entre dispositivos
 
 2. **Sistema de Autenticação**
-   - Adicionar login e controle de acesso
+   - Login básico com senha implementado utilizando localStorage
    - Definir diferentes níveis de usuário
 
 3. **Funcionalidades Adicionais**
-   - Controle de estoque
    - Exportação de relatórios em PDF/Excel
    - Planejamento de produção
 
 ## Conclusão
 
-O Sistema de Gestão Gastronômica está pronto para uso e foi desenvolvido seguindo as melhores práticas de desenvolvimento web moderno. A documentação fornecida permite tanto o uso imediato por usuários finais quanto a manutenção e evolução por desenvolvedores.
+O Sistema de Controle - Fichas Técnicas está pronto para uso e foi desenvolvido seguindo as melhores práticas de desenvolvimento web moderno. A documentação fornecida permite tanto o uso imediato por usuários finais quanto a manutenção e evolução por desenvolvedores.
 
 ---
 

--- a/docs/guia-desenvolvimento.md
+++ b/docs/guia-desenvolvimento.md
@@ -1,6 +1,6 @@
 # Guia de Desenvolvimento e Manutenção
 
-Este documento fornece informações técnicas sobre a estrutura do código, arquitetura e práticas de desenvolvimento do Sistema de Gestão Gastronômica.
+Este documento fornece informações técnicas sobre a estrutura do código, arquitetura e práticas de desenvolvimento do Sistema de Controle - Fichas Técnicas.
 
 ## Arquitetura do Sistema
 
@@ -17,6 +17,7 @@ sistema-gastronomico-novo/
 │   │   ├── configuracoes/   # Módulo de configurações
 │   │   ├── fichas-tecnicas/ # Módulo de fichas técnicas
 │   │   ├── produtos/        # Módulo de produtos
+│   │   ├── estoque/         # Módulo de controle de estoque
 │   │   ├── relatorios/      # Módulo de relatórios
 │   │   ├── layout.tsx       # Layout principal da aplicação
 │   │   └── page.tsx         # Página inicial (dashboard)
@@ -75,6 +76,23 @@ Gera relatórios baseados nos dados de produtos e fichas técnicas:
 - `useRelatorios()`: Hook que fornece funções para gerar diferentes tipos de relatórios
 - Funções: `gerarRelatorioCompleto`, `gerarRelatorioCustos`, `gerarRelatorioIngredientes`, `gerarRelatorioReceitas`
 - Cálculos de métricas e estatísticas
+
+### usuariosService.ts
+
+Gerencia autenticação e cadastro de usuários:
+
+- `useUsuarios()`: Hook para acessar usuários e funções de login
+- Funções: `registrarUsuario`, `login`, `logout`, `removerUsuario`, `alterarSenha`
+- Persistência em localStorage
+
+### estoqueService.ts
+
+Gerencia o histórico de compras e a quantidade em estoque:
+
+- `useEstoque()`: Hook para registrar entradas de produtos
+- Funções: `registrarCompra`, `obterHistoricoPorProduto`, `calcularEstoqueAtual`
+- Atualiza automaticamente o preço dos produtos e os custos das fichas técnicas
+- Persistência em localStorage
 
 ## Padrões de Código
 
@@ -148,7 +166,7 @@ Para fazer deploy:
 Áreas para desenvolvimento futuro:
 
 1. **Autenticação e Autorização**:
-   - Implementar sistema de login
+   - Sistema de login implementado utilizando armazenamento local
    - Definir níveis de acesso para diferentes usuários
 
 2. **Banco de Dados Remoto**:

--- a/docs/manual-usuario.md
+++ b/docs/manual-usuario.md
@@ -1,8 +1,8 @@
-# Documentação do Sistema de Gestão Gastronômica
+# Documentação do Sistema de Controle - Fichas Técnicas
 
 ## Visão Geral
 
-O Sistema de Gestão Gastronômica é uma aplicação web completa desenvolvida para auxiliar estabelecimentos gastronômicos no gerenciamento de produtos, fichas técnicas (receitas) e relatórios. O sistema permite o controle eficiente de insumos, cálculo automático de custos e informações nutricionais, além de fornecer relatórios detalhados para tomada de decisões.
+O Sistema de Controle - Fichas Técnicas é uma aplicação web completa desenvolvida para auxiliar estabelecimentos gastronômicos no gerenciamento de produtos, fichas técnicas (receitas) e relatórios. O sistema permite o controle eficiente de insumos, cálculo automático de custos e informações nutricionais, além de fornecer relatórios detalhados para tomada de decisões.
 
 ## Estrutura do Sistema
 
@@ -46,6 +46,21 @@ O sistema foi desenvolvido utilizando tecnologias modernas:
 
 ## Guia de Uso
 
+### Acesso ao Sistema
+
+1. Acesse a página de login (`/login`).
+2. Caso seja o primeiro acesso, clique em "Cadastre-se" para criar um usuário.
+3. Informe seu email e senha para entrar no sistema. As credenciais ficam armazenadas somente no navegador.
+
+### Controle de Usuários
+
+1. Acesse "Configurações" no menu lateral.
+2. Clique em "Controle de Usuários".
+3. Utilize o botão "Novo Usuário" para cadastrar novas contas.
+4. Exclua usuários indesejados pelo botão "Excluir" na tabela.
+5. Altere senhas existentes clicando em "Alterar Senha" ao lado do usuário.
+6. Em "Unidades de Medida" é possível cadastrar, editar ou remover siglas utilizadas nos produtos.
+
 ### Produtos/Insumos
 
 1. **Listagem de Produtos**:
@@ -67,6 +82,16 @@ O sistema foi desenvolvido utilizando tecnologias modernas:
 4. **Exclusão de Produto**:
    - Na listagem de produtos, clique no botão de exclusão
    - Confirme a exclusão
+
+### Controle de Estoque
+
+1. **Registrar Compras**:
+   - Acesse a página "Estoque" no menu lateral
+   - Selecione o produto comprado e informe quantidade, preço e fornecedor
+   - Clique em "Registrar Entrada" para salvar
+2. **Histórico**:
+   - A tabela abaixo do formulário mostra todas as entradas realizadas
+   - Os preços informados atualizam automaticamente o cadastro do produto e as fichas técnicas relacionadas
 
 ### Fichas Técnicas
 
@@ -114,14 +139,14 @@ O sistema utiliza localStorage para persistência de dados, o que significa que:
 
 ### Limitações Atuais
 
-- O sistema não possui autenticação de usuários
-- Não há sincronização de dados entre dispositivos
+- O sistema conta com autenticação básica de usuários, mas as credenciais ficam armazenadas localmente
+- Não há sincronização de dados entre diferentes dispositivos
 - A exportação de relatórios para PDF e Excel está planejada para versões futuras
 
 ### Próximas Versões
 
 Estão planejadas para versões futuras:
-- Autenticação de usuários
+- Diferentes níveis de permissão para usuários
 - Banco de dados remoto para sincronização entre dispositivos
 - Exportação de relatórios em diferentes formatos
 - Controle de estoque

--- a/docs/requisitos.md
+++ b/docs/requisitos.md
@@ -1,4 +1,4 @@
-# Requisitos do Sistema de Gestão Gastronômica
+# Requisitos do Sistema de Controle - Fichas Técnicas
 
 ## 1. Cadastro de Produtos (Insumos)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends("next/core-web-vitals"),
 ];
 
 export default eslintConfig;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/app/configuracoes/categorias/page.tsx
+++ b/src/app/configuracoes/categorias/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+import Table, { TableRow, TableCell } from '@/components/ui/Table';
+import Button from '@/components/ui/Button';
+import Modal, { useModal } from '@/components/ui/Modal';
+import Input from '@/components/ui/Input';
+import { useCategorias } from '@/lib/categoriasService';
+
+export default function CategoriasConfigPage() {
+  const { categorias, adicionarCategoria, atualizarCategoria, removerCategoria } = useCategorias();
+  const { isOpen, openModal, closeModal } = useModal();
+  const { isOpen: isEditOpen, openModal: openEdit, closeModal: closeEdit } = useModal();
+  const [nova, setNova] = useState('');
+  const [editar, setEditar] = useState({ id: '', nome: '' });
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault();
+    adicionarCategoria(nova.trim());
+    setNova('');
+    closeModal();
+  };
+
+  const iniciarEdicao = (id: string, nome: string) => {
+    setEditar({ id, nome });
+    openEdit();
+  };
+
+  const handleEdit = (e: React.FormEvent) => {
+    e.preventDefault();
+    atualizarCategoria(editar.id, editar.nome.trim());
+    closeEdit();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-800">Categorias de Produtos</h1>
+      <Button onClick={openModal} variant="primary">Nova Categoria</Button>
+      <Table headers={["Nome", "Ações"]}>
+        {categorias.map(cat => (
+          <TableRow key={cat.id}>
+            <TableCell>{cat.nome}</TableCell>
+            <TableCell className="space-x-2">
+              <Button size="sm" variant="secondary" onClick={() => iniciarEdicao(cat.id, cat.nome)}>Editar</Button>
+              <Button size="sm" variant="danger" onClick={() => removerCategoria(cat.id)}>Excluir</Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </Table>
+      <Modal isOpen={isOpen} onClose={closeModal} title="Nova Categoria">
+        <form onSubmit={handleAdd} className="space-y-4">
+          <Input label="Nome" value={nova} onChange={e => setNova(e.target.value)} required />
+          <div className="flex justify-end space-x-2">
+            <Button type="button" variant="secondary" onClick={closeModal}>Cancelar</Button>
+            <Button type="submit" variant="primary">Salvar</Button>
+          </div>
+        </form>
+      </Modal>
+      <Modal isOpen={isEditOpen} onClose={closeEdit} title="Editar Categoria">
+        <form onSubmit={handleEdit} className="space-y-4">
+          <Input label="Nome" value={editar.nome} onChange={e => setEditar({ ...editar, nome: e.target.value })} required />
+          <div className="flex justify-end space-x-2">
+            <Button type="button" variant="secondary" onClick={closeEdit}>Cancelar</Button>
+            <Button type="submit" variant="primary">Salvar</Button>
+          </div>
+        </form>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/configuracoes/page.tsx
+++ b/src/app/configuracoes/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+import Link from 'next/link';
+
+export default function ConfiguracoesPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-800">Configurações</h1>
+      <ul className="list-disc pl-6 space-y-2 text-blue-600">
+        <li>
+          <Link href="/configuracoes/usuarios" className="hover:underline">
+            Controle de Usuários
+          </Link>
+        </li>
+        <li>
+          <Link href="/configuracoes/categorias" className="hover:underline">
+            Categorias de Produtos
+          </Link>
+        </li>
+        <li>
+          <Link href="/configuracoes/unidades" className="hover:underline">
+            Unidades de Medida
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/app/configuracoes/unidades/page.tsx
+++ b/src/app/configuracoes/unidades/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+import Table, { TableRow, TableCell } from '@/components/ui/Table';
+import Button from '@/components/ui/Button';
+import Modal, { useModal } from '@/components/ui/Modal';
+import Input from '@/components/ui/Input';
+import { useUnidadesMedida } from '@/lib/unidadesService';
+
+export default function UnidadesConfigPage() {
+  const { unidades, adicionarUnidade, atualizarUnidade, removerUnidade } = useUnidadesMedida();
+  const { isOpen, openModal, closeModal } = useModal();
+  const { isOpen: isEditOpen, openModal: openEdit, closeModal: closeEdit } = useModal();
+  const [nova, setNova] = useState({ id: '', nome: '' });
+  const [editar, setEditar] = useState({ id: '', nome: '' });
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault();
+    adicionarUnidade(nova.id.trim(), nova.nome.trim());
+    setNova({ id: '', nome: '' });
+    closeModal();
+  };
+
+  const iniciarEdicao = (id: string, nome: string) => {
+    setEditar({ id, nome });
+    openEdit();
+  };
+
+  const handleEdit = (e: React.FormEvent) => {
+    e.preventDefault();
+    atualizarUnidade(editar.id, editar.nome.trim());
+    closeEdit();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-800">Unidades de Medida</h1>
+      <Button onClick={openModal} variant="primary">Nova Unidade</Button>
+      <Table headers={["Sigla", "Nome", "Ações"]}>
+        {unidades.map(u => (
+          <TableRow key={u.id}>
+            <TableCell>{u.id}</TableCell>
+            <TableCell>{u.nome}</TableCell>
+            <TableCell className="space-x-2">
+              <Button size="sm" variant="secondary" onClick={() => iniciarEdicao(u.id, u.nome)}>Editar</Button>
+              <Button size="sm" variant="danger" onClick={() => removerUnidade(u.id)}>Excluir</Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </Table>
+      <Modal isOpen={isOpen} onClose={closeModal} title="Nova Unidade">
+        <form onSubmit={handleAdd} className="space-y-4">
+          <Input label="Sigla" value={nova.id} onChange={e => setNova({ ...nova, id: e.target.value })} required />
+          <Input label="Nome" value={nova.nome} onChange={e => setNova({ ...nova, nome: e.target.value })} required />
+          <div className="flex justify-end space-x-2">
+            <Button type="button" variant="secondary" onClick={closeModal}>Cancelar</Button>
+            <Button type="submit" variant="primary">Salvar</Button>
+          </div>
+        </form>
+      </Modal>
+      <Modal isOpen={isEditOpen} onClose={closeEdit} title="Editar Unidade">
+        <form onSubmit={handleEdit} className="space-y-4">
+          <Input label="Sigla" value={editar.id} disabled />
+          <Input label="Nome" value={editar.nome} onChange={e => setEditar({ ...editar, nome: e.target.value })} required />
+          <div className="flex justify-end space-x-2">
+            <Button type="button" variant="secondary" onClick={closeEdit}>Cancelar</Button>
+            <Button type="submit" variant="primary">Salvar</Button>
+          </div>
+        </form>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/configuracoes/usuarios/page.tsx
+++ b/src/app/configuracoes/usuarios/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState } from 'react';
+import Table, { TableRow, TableCell } from '@/components/ui/Table';
+import Button from '@/components/ui/Button';
+import Modal, { useModal } from '@/components/ui/Modal';
+import Input from '@/components/ui/Input';
+import { useUsuarios } from '@/lib/usuariosService';
+
+export default function UsuariosConfigPage() {
+  const { usuarios, registrarUsuario, removerUsuario, alterarSenha } = useUsuarios();
+  const { isOpen, openModal, closeModal } = useModal();
+  const { isOpen: isSenhaOpen, openModal: openSenhaModal, closeModal: closeSenhaModal } = useModal();
+  const [novo, setNovo] = useState({ nome: '', email: '', senha: '', confirmarSenha: '' });
+  const [erro, setErro] = useState('');
+  const [senhaForm, setSenhaForm] = useState({ id: '', senha: '', confirmarSenha: '' });
+  const [erroSenha, setErroSenha] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (novo.senha !== novo.confirmarSenha) {
+      setErro('Senhas não conferem');
+      return;
+    }
+    registrarUsuario({ nome: novo.nome, email: novo.email, senha: novo.senha });
+    setNovo({ nome: '', email: '', senha: '', confirmarSenha: '' });
+    setErro('');
+    closeModal();
+  };
+
+  const iniciarAlterarSenha = (id: string) => {
+    setSenhaForm({ id, senha: '', confirmarSenha: '' });
+    setErroSenha('');
+    openSenhaModal();
+  };
+
+  const handleAlterarSenha = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (senhaForm.senha !== senhaForm.confirmarSenha) {
+      setErroSenha('Senhas não conferem');
+      return;
+    }
+    alterarSenha(senhaForm.id, senhaForm.senha);
+    closeSenhaModal();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-800">Controle de Usuários</h1>
+      <Button onClick={openModal} variant="primary">Novo Usuário</Button>
+      <Table headers={["Nome", "Email", "Ações"]}>
+        {usuarios.map(u => (
+          <TableRow key={u.id}>
+            <TableCell>{u.nome}</TableCell>
+            <TableCell>{u.email}</TableCell>
+            <TableCell className="space-x-2">
+              <Button size="sm" variant="secondary" onClick={() => iniciarAlterarSenha(u.id)}>
+                Alterar Senha
+              </Button>
+              <Button size="sm" variant="danger" onClick={() => removerUsuario(u.id)}>
+                Excluir
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </Table>
+
+      <Modal isOpen={isOpen} onClose={closeModal} title="Novo Usuário">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {erro && <p className="text-sm text-red-600">{erro}</p>}
+          <Input label="Nome" value={novo.nome} onChange={e => setNovo({ ...novo, nome: e.target.value })} required />
+          <Input label="Email" type="email" value={novo.email} onChange={e => setNovo({ ...novo, email: e.target.value })} required />
+          <Input label="Senha" type="password" value={novo.senha} onChange={e => setNovo({ ...novo, senha: e.target.value })} required />
+          <Input label="Confirmar Senha" type="password" value={novo.confirmarSenha} onChange={e => setNovo({ ...novo, confirmarSenha: e.target.value })} required />
+          <div className="flex justify-end space-x-2">
+            <Button type="button" variant="secondary" onClick={closeModal}>Cancelar</Button>
+            <Button type="submit" variant="primary">Salvar</Button>
+          </div>
+        </form>
+      </Modal>
+
+      <Modal isOpen={isSenhaOpen} onClose={closeSenhaModal} title="Alterar Senha">
+        <form onSubmit={handleAlterarSenha} className="space-y-4">
+          {erroSenha && <p className="text-sm text-red-600">{erroSenha}</p>}
+          <Input
+            label="Nova Senha"
+            type="password"
+            value={senhaForm.senha}
+            onChange={e => setSenhaForm({ ...senhaForm, senha: e.target.value })}
+            required
+          />
+          <Input
+            label="Confirmar Senha"
+            type="password"
+            value={senhaForm.confirmarSenha}
+            onChange={e => setSenhaForm({ ...senhaForm, confirmarSenha: e.target.value })}
+            required
+          />
+          <div className="flex justify-end space-x-2">
+            <Button type="button" variant="secondary" onClick={closeSenhaModal}>Cancelar</Button>
+            <Button type="submit" variant="primary">Salvar</Button>
+          </div>
+        </form>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/estoque/page.tsx
+++ b/src/app/estoque/page.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import React, { useState } from 'react';
+import Card from '@/components/ui/Card';
+import Table, { TableRow, TableCell } from '@/components/ui/Table';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import Select from '@/components/ui/Select';
+import { useEstoque } from '@/lib/estoqueService';
+import { useProdutos, ProdutoInfo } from '@/lib/produtosService';
+
+export default function EstoquePage() {
+  const { movimentacoes, isLoading, registrarEntrada, registrarSaida } = useEstoque();
+  const { produtos } = useProdutos();
+
+  const [form, setForm] = useState({
+    tipo: 'entrada',
+    produtoId: '',
+    quantidade: '',
+    preco: '',
+    fornecedor: '',
+    marca: ''
+  });
+  const [erros, setErros] = useState<Record<string, string>>({});
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const validar = () => {
+    const errs: Record<string, string> = {};
+    if (!form.produtoId) errs.produtoId = 'Produto é obrigatório';
+    if (!form.quantidade || isNaN(Number(form.quantidade))) errs.quantidade = 'Qtd inválida';
+    if (form.tipo === 'entrada') {
+      if (!form.preco || isNaN(Number(form.preco.replace(',', '.')))) errs.preco = 'Preço inválido';
+      if (!form.fornecedor) errs.fornecedor = 'Fornecedor obrigatório';
+    }
+    setErros(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validar()) return;
+    if (form.tipo === 'entrada') {
+      registrarEntrada({
+        produtoId: form.produtoId,
+        quantidade: Number(form.quantidade),
+        preco: Number(form.preco.replace(',', '.')),
+        fornecedor: form.fornecedor,
+        marca: form.marca
+      });
+    } else {
+      registrarSaida({
+        produtoId: form.produtoId,
+        quantidade: Number(form.quantidade)
+      });
+    }
+    setForm({ tipo: 'entrada', produtoId: '', quantidade: '', preco: '', fornecedor: '', marca: '' });
+  };
+
+  const formatarData = (d: string) => new Date(d).toLocaleDateString();
+  const formatarPreco = (v: number) => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-800">Controle de Estoque</h1>
+
+      <Card>
+        <form onSubmit={handleSubmit} className="grid grid-cols-1 md:grid-cols-6 gap-4">
+          <Select
+            label="Produto *"
+            name="produtoId"
+            value={form.produtoId}
+            onChange={handleChange}
+            options={produtos.map((p: ProdutoInfo) => ({ value: p.id, label: p.nome }))}
+            error={erros.produtoId}
+          />
+          <Select
+            label="Tipo *"
+            name="tipo"
+            value={form.tipo}
+            onChange={handleChange}
+            options={[{ value: 'entrada', label: 'Entrada' }, { value: 'saida', label: 'Saída' }]}
+          />
+          <Input label="Quantidade *" name="quantidade" value={form.quantidade} onChange={handleChange} error={erros.quantidade} />
+          {form.tipo === 'entrada' && (
+            <>
+              <Input label="Preço Unitário *" name="preco" value={form.preco} onChange={handleChange} error={erros.preco} />
+              <Input label="Fornecedor *" name="fornecedor" value={form.fornecedor} onChange={handleChange} error={erros.fornecedor} />
+              <Input label="Marca" name="marca" value={form.marca} onChange={handleChange} />
+            </>
+          )}
+          <div className="md:col-span-6 flex justify-end">
+            <Button type="submit" variant="primary">Registrar {form.tipo === 'entrada' ? 'Entrada' : 'Saída'}</Button>
+          </div>
+        </form>
+      </Card>
+
+      <Card>
+        <Table
+          headers={["Data", "Produto", "Qtd", "Preço", "Fornecedor", "Marca", "Tipo"]}
+          isLoading={isLoading}
+          emptyMessage="Nenhuma movimentação registrada"
+        >
+          {movimentacoes.map(m => {
+            const prod = produtos.find(p => p.id === m.produtoId);
+            return (
+              <TableRow key={m.id}>
+                <TableCell>{formatarData(m.data)}</TableCell>
+                <TableCell>{prod?.nome || 'Produto removido'}</TableCell>
+                <TableCell>{m.quantidade}</TableCell>
+                <TableCell>{m.preco ? formatarPreco(m.preco) : '-'}</TableCell>
+                <TableCell>{m.fornecedor || '-'}</TableCell>
+                <TableCell>{m.marca || '-'}</TableCell>
+                <TableCell>{m.tipo === 'entrada' ? 'Entrada' : 'Saída'}</TableCell>
+              </TableRow>
+            );
+          })}
+        </Table>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/fichas-tecnicas/[id]/imprimir/page.tsx
+++ b/src/app/fichas-tecnicas/[id]/imprimir/page.tsx
@@ -1,42 +1,30 @@
 'use client';
-import React from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import React, { useEffect } from 'react';
+import { useParams } from 'next/navigation';
 import Card from '@/components/ui/Card';
-import Button from '@/components/ui/Button';
-import {
-  useFichasTecnicas,
-  obterLabelCategoriaReceita
-} from '@/lib/fichasTecnicasService';
+import { useFichasTecnicas, obterLabelCategoriaReceita } from '@/lib/fichasTecnicasService';
 import { useProdutos } from '@/lib/produtosService';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 
-export default function DetalheFichaTecnicaPage() {
+export default function ImprimirFichaTecnicaPage() {
   const params = useParams();
-  const router = useRouter();
-  const { obterFichaTecnicaPorId, removerFichaTecnica } = useFichasTecnicas();
+  const { obterFichaTecnicaPorId } = useFichasTecnicas();
   const { produtos } = useProdutos();
-  
+
   const fichaId = params.id as string;
   const ficha = obterFichaTecnicaPorId(fichaId);
-  
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.print();
+    }
+  }, []);
+
   if (!ficha) {
     return (
-      <div className="text-center py-12">
-        <h2 className="text-2xl font-bold text-gray-800 mb-4">Ficha técnica não encontrada</h2>
-        <p className="text-gray-600 mb-6">A ficha técnica que você está procurando não existe ou foi removida.</p>
-        <Button variant="primary" onClick={() => router.push('/fichas-tecnicas')}>
-          Voltar para Fichas Técnicas
-        </Button>
-      </div>
+      <div className="p-8 text-center">Ficha técnica não encontrada</div>
     );
   }
-
-  const handleRemover = () => {
-    if (confirm('Tem certeza que deseja remover esta ficha técnica?')) {
-      removerFichaTecnica(fichaId);
-      router.push('/fichas-tecnicas');
-    }
-  };
 
   const formatarPreco = (preco: number) => {
     return new Intl.NumberFormat('pt-BR', {
@@ -54,110 +42,68 @@ export default function DetalheFichaTecnicaPage() {
     }).format(data);
   };
 
-  // Obter nome do produto pelo ID
   const getNomeProduto = (produtoId: string) => {
     const produto = produtos.find(p => p.id === produtoId);
     return produto ? produto.nome : 'Produto não encontrado';
   };
 
-  // Formatar quantidade com unidade de medida
   const formatarQuantidade = (unidade: string, quantidade: number) => {
     return `${quantidade} ${unidade}`;
   };
 
-  // Formatar valor nutricional
   const formatarValorNutricional = (valor: number, unidade: string) => {
     return `${valor.toFixed(2)} ${unidade}`;
   };
 
   return (
-    <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <h1 className="text-2xl font-bold text-gray-800">Ficha Técnica</h1>
-        <div className="flex space-x-3">
-          <Button 
-            variant="outline" 
-            onClick={() => router.push('/fichas-tecnicas')}
-          >
-            Voltar
-          </Button>
-          <Button
-            variant="primary"
-            onClick={() => router.push(`/fichas-tecnicas/${fichaId}/editar`)}
-          >
-            Editar
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => router.push(`/fichas-tecnicas/${fichaId}/imprimir`)}
-          >
-            Imprimir
-          </Button>
-          <Button
-            variant="danger"
-            onClick={handleRemover}
-          >
-            Remover
-          </Button>
-        </div>
-      </div>
-      
+    <div className="p-8 space-y-6">
+      <h1 className="text-2xl font-bold text-center">Ficha Técnica</h1>
       <Card title="Informações Básicas">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
           <div>
             <h3 className="text-sm font-medium text-gray-500">Nome da Receita</h3>
             <p className="mt-1 text-lg font-medium text-gray-900">{ficha.nome}</p>
           </div>
-          
           <div>
             <h3 className="text-sm font-medium text-gray-500">Categoria</h3>
             <p className="mt-1 text-lg font-medium text-gray-900">{obterLabelCategoriaReceita(ficha.categoria)}</p>
           </div>
         </div>
-        
         {ficha.descricao && (
           <div className="mb-6">
             <h3 className="text-sm font-medium text-gray-500">Descrição</h3>
             <p className="mt-1 text-gray-700">{ficha.descricao}</p>
           </div>
         )}
-        
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div>
             <h3 className="text-sm font-medium text-gray-500">Tempo de Preparo</h3>
             <p className="mt-1 text-lg font-medium text-gray-900">{ficha.tempoPreparo} minutos</p>
           </div>
-          
           <div>
             <h3 className="text-sm font-medium text-gray-500">Rendimento</h3>
             <p className="mt-1 text-lg font-medium text-gray-900">{ficha.rendimentoTotal} {ficha.unidadeRendimento}</p>
           </div>
-          
           <div>
             <h3 className="text-sm font-medium text-gray-500">Data de Criação</h3>
             <p className="mt-1 text-lg font-medium text-gray-900">{formatarData(ficha.dataCriacao)}</p>
           </div>
         </div>
       </Card>
-      
       <Card title="Custos">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="bg-gray-50 p-4 rounded-lg">
             <h3 className="text-sm font-medium text-gray-500">Custo Total</h3>
             <p className="mt-1 text-xl font-medium text-gray-900">{formatarPreco(ficha.custoTotal)}</p>
           </div>
-          
           <div className="bg-gray-50 p-4 rounded-lg">
             <h3 className="text-sm font-medium text-gray-500">Custo por Porção</h3>
             <p className="mt-1 text-xl font-medium text-gray-900">{formatarPreco(ficha.custoPorcao)}</p>
           </div>
         </div>
       </Card>
-      
       <Card title="Ingredientes">
-        <Table
-          headers={['Produto', 'Quantidade', 'Custo']}
-        >
+        <Table headers={['Produto', 'Quantidade', 'Custo']}>
           {ficha.ingredientes.map((ingrediente, index) => (
             <TableRow key={index}>
               <TableCell>{getNomeProduto(ingrediente.produtoId)}</TableCell>
@@ -167,13 +113,11 @@ export default function DetalheFichaTecnicaPage() {
           ))}
         </Table>
       </Card>
-      
       <Card title="Modo de Preparo">
         <div className="whitespace-pre-line text-gray-700">
           {ficha.modoPreparo}
         </div>
       </Card>
-      
       {ficha.infoNutricional && (
         <Card title="Informações Nutricionais">
           <div className="grid grid-cols-2 gap-4">
@@ -186,21 +130,18 @@ export default function DetalheFichaTecnicaPage() {
                     {formatarValorNutricional(ficha.infoNutricional.calorias, 'kcal')}
                   </p>
                 </div>
-                
                 <div className="bg-gray-50 p-4 rounded-lg">
                   <h4 className="text-sm font-medium text-gray-500">Carboidratos</h4>
                   <p className="mt-1 text-lg font-medium text-gray-900">
                     {formatarValorNutricional(ficha.infoNutricional.carboidratos, 'g')}
                   </p>
                 </div>
-                
                 <div className="bg-gray-50 p-4 rounded-lg">
                   <h4 className="text-sm font-medium text-gray-500">Proteínas</h4>
                   <p className="mt-1 text-lg font-medium text-gray-900">
                     {formatarValorNutricional(ficha.infoNutricional.proteinas, 'g')}
                   </p>
                 </div>
-                
                 <div className="bg-gray-50 p-4 rounded-lg">
                   <h4 className="text-sm font-medium text-gray-500">Gorduras Totais</h4>
                   <p className="mt-1 text-lg font-medium text-gray-900">
@@ -209,7 +150,6 @@ export default function DetalheFichaTecnicaPage() {
                 </div>
               </div>
             </div>
-            
             <div>
               <h3 className="text-lg font-medium text-gray-900 mb-4">Por Porção</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -219,21 +159,18 @@ export default function DetalheFichaTecnicaPage() {
                     {formatarValorNutricional(ficha.infoNutricionalPorcao?.calorias ?? 0, 'kcal')}
                   </p>
                 </div>
-                
                 <div className="bg-gray-50 p-4 rounded-lg">
                   <h4 className="text-sm font-medium text-gray-500">Carboidratos</h4>
                   <p className="mt-1 text-lg font-medium text-gray-900">
                     {formatarValorNutricional(ficha.infoNutricionalPorcao?.carboidratos ?? 0, 'g')}
                   </p>
                 </div>
-                
                 <div className="bg-gray-50 p-4 rounded-lg">
                   <h4 className="text-sm font-medium text-gray-500">Proteínas</h4>
                   <p className="mt-1 text-lg font-medium text-gray-900">
                     {formatarValorNutricional(ficha.infoNutricionalPorcao?.proteinas ?? 0, 'g')}
                   </p>
                 </div>
-                
                 <div className="bg-gray-50 p-4 rounded-lg">
                   <h4 className="text-sm font-medium text-gray-500">Gorduras Totais</h4>
                   <p className="mt-1 text-lg font-medium text-gray-900">
@@ -245,7 +182,6 @@ export default function DetalheFichaTecnicaPage() {
           </div>
         </Card>
       )}
-      
       {ficha.observacoes && (
         <Card title="Observações">
           <div className="whitespace-pre-line text-gray-700">

--- a/src/app/fichas-tecnicas/nova/page.tsx
+++ b/src/app/fichas-tecnicas/nova/page.tsx
@@ -7,29 +7,50 @@ import Input from '@/components/ui/Input';
 import Select from '@/components/ui/Select';
 import Textarea from '@/components/ui/Textarea';
 import Button from '@/components/ui/Button';
-import { useFichasTecnicas, categoriasReceitas, unidadesRendimento } from '@/lib/fichasTecnicasService';
+import { useFichasTecnicas, categoriasReceitas, unidadesRendimento, FichaTecnicaInfo, IngredienteFicha } from '@/lib/fichasTecnicasService';
 import { useProdutos } from '@/lib/produtosService';
+import { useUnidadesMedida } from '@/lib/unidadesService';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 import { useModal } from '@/components/ui/Modal';
 import Modal from '@/components/ui/Modal';
+
+type Ingrediente = Omit<IngredienteFicha, 'id' | 'custo'>;
+
+interface FichaTecnicaForm {
+  nome: string;
+  descricao: string;
+  categoria: string;
+  ingredientes: Ingrediente[];
+  modoPreparo: string;
+  tempoPreparo: string;
+  rendimentoTotal: string;
+  unidadeRendimento: string;
+  observacoes: string;
+}
 
 export default function NovaFichaTecnicaPage() {
   const router = useRouter();
   const { adicionarFichaTecnica } = useFichasTecnicas();
   const { produtos } = useProdutos();
+  const { unidades } = useUnidadesMedida();
   const [isLoading, setIsLoading] = useState(false);
   
   // Modal para adicionar ingredientes
   const { isOpen, openModal, closeModal } = useModal();
   
   // Estado para o ingrediente sendo adicionado
-  const [ingredienteAtual, setIngredienteAtual] = useState({
+  const [ingredienteAtual, setIngredienteAtual] = useState<{
+    produtoId: string;
+    quantidade: string;
+    unidade: string;
+  }>({
     produtoId: '',
     quantidade: '',
+    unidade: '',
   });
   
   // Estado para a ficha técnica
-  const [fichaTecnica, setFichaTecnica] = useState({
+  const [fichaTecnica, setFichaTecnica] = useState<FichaTecnicaForm>({
     nome: '',
     descricao: '',
     categoria: '',
@@ -55,10 +76,14 @@ export default function NovaFichaTecnicaPage() {
   // Manipular mudanças nos campos do ingrediente atual
   const handleIngredienteChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
-    setIngredienteAtual(prev => ({
-      ...prev,
-      [name]: value
-    }));
+    setIngredienteAtual(prev => {
+      const atualizado = { ...prev, [name]: value };
+      if (name === 'produtoId') {
+        const prod = produtos.find(p => p.id === value);
+        if (prod) atualizado.unidade = prod.unidadeMedida;
+      }
+      return atualizado;
+    });
   };
 
   // Adicionar ingrediente à lista
@@ -75,6 +100,10 @@ export default function NovaFichaTecnicaPage() {
     } else if (isNaN(Number(ingredienteAtual.quantidade)) || Number(ingredienteAtual.quantidade) <= 0) {
       errosIngrediente.quantidade = 'Quantidade deve ser um número positivo';
     }
+
+    if (!ingredienteAtual.unidade) {
+      errosIngrediente.unidade = 'Selecione a unidade';
+    }
     
     if (Object.keys(errosIngrediente).length > 0) {
       setErros(prev => ({ ...prev, ...errosIngrediente }));
@@ -85,6 +114,7 @@ export default function NovaFichaTecnicaPage() {
     const novoIngrediente = {
       produtoId: ingredienteAtual.produtoId,
       quantidade: Number(ingredienteAtual.quantidade),
+      unidade: ingredienteAtual.unidade,
     };
     
     setFichaTecnica(prev => ({
@@ -96,6 +126,7 @@ export default function NovaFichaTecnicaPage() {
     setIngredienteAtual({
       produtoId: '',
       quantidade: '',
+      unidade: '',
     });
     
     // Limpar erros
@@ -103,6 +134,7 @@ export default function NovaFichaTecnicaPage() {
       const novosErros = { ...prev };
       delete novosErros.produtoId;
       delete novosErros.quantidade;
+      delete novosErros.unidade;
       return novosErros;
     });
     
@@ -162,7 +194,7 @@ export default function NovaFichaTecnicaPage() {
         ...fichaTecnica,
         tempoPreparo: Number(fichaTecnica.tempoPreparo),
         rendimentoTotal: Number(fichaTecnica.rendimentoTotal),
-      };
+      } as unknown as Omit<FichaTecnicaInfo, 'id' | 'custoTotal' | 'custoPorcao' | 'infoNutricional' | 'infoNutricionalPorcao' | 'dataCriacao' | 'ultimaAtualizacao'>;
       
       adicionarFichaTecnica(fichaTecnicaFormatada);
       router.push('/fichas-tecnicas');
@@ -181,9 +213,9 @@ export default function NovaFichaTecnicaPage() {
   };
 
   // Formatar quantidade com unidade de medida
-  const formatarQuantidade = (produtoId: string, quantidade: number) => {
-    const produto = produtos.find(p => p.id === produtoId);
-    return produto ? `${quantidade} ${produto.unidadeMedida}` : `${quantidade}`;
+  const formatarQuantidade = (unidade: string, quantidade: number) => {
+    const label = unidades.find(u => u.id === unidade)?.id || unidade;
+    return `${quantidade} ${label}`;
   };
 
   return (
@@ -283,7 +315,7 @@ export default function NovaFichaTecnicaPage() {
                 {fichaTecnica.ingredientes.map((ingrediente, index) => (
                   <TableRow key={index}>
                     <TableCell>{getNomeProduto(ingrediente.produtoId)}</TableCell>
-                    <TableCell>{formatarQuantidade(ingrediente.produtoId, ingrediente.quantidade)}</TableCell>
+                    <TableCell>{formatarQuantidade(ingrediente.unidade, ingrediente.quantidade)}</TableCell>
                     <TableCell>
                       <Button
                         variant="outline"
@@ -366,7 +398,7 @@ export default function NovaFichaTecnicaPage() {
             error={erros.produtoId}
             options={produtos.map(p => ({ value: p.id, label: `${p.nome} (${p.unidadeMedida})` }))}
           />
-          
+
           <Input
             label="Quantidade *"
             name="quantidade"
@@ -377,6 +409,15 @@ export default function NovaFichaTecnicaPage() {
             onChange={handleIngredienteChange}
             error={erros.quantidade}
             placeholder="Ex: 250"
+          />
+
+          <Select
+            label="Unidade *"
+            name="unidade"
+            value={ingredienteAtual.unidade}
+            onChange={handleIngredienteChange}
+            error={erros.unidade}
+            options={unidades.map(u => ({ value: u.id, label: u.nome }))}
           />
         </div>
       </Modal>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import MainLayout from "@/components/layout/MainLayout";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Sistema de Gestão Gastronômica",
+  title: "Sistema de Controle - Fichas Técnicas",
   description: "Sistema para gerenciamento de fichas técnicas e produtos gastronômicos",
 };
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import Card from '@/components/ui/Card';
+import Input from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+import { useUsuarios } from '@/lib/usuariosService';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { login, usuarioAtual } = useUsuarios();
+  const [email, setEmail] = useState('');
+  const [senha, setSenha] = useState('');
+  const [erro, setErro] = useState('');
+
+  if (usuarioAtual) {
+    router.push('/');
+    return null;
+  }
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const usuario = login(email, senha);
+    if (usuario) {
+      router.push('/');
+    } else {
+      setErro('Credenciais inválidas');
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-100">
+      <Card className="w-96">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <h1 className="text-xl font-bold text-gray-800">Entrar</h1>
+          {erro && <p className="text-sm text-red-600">{erro}</p>}
+          <Input
+            label="Email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <Input
+            label="Senha"
+            type="password"
+            value={senha}
+            onChange={(e) => setSenha(e.target.value)}
+            required
+          />
+          <Button type="submit" variant="primary" fullWidth>
+            Entrar
+          </Button>
+          <p className="text-sm">
+            Não possui conta?{' '}
+            <Link href="/usuarios/novo" className="text-blue-600 hover:underline">
+              Cadastre-se
+            </Link>
+          </p>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/produtos/[id]/editar/page.tsx
+++ b/src/app/produtos/[id]/editar/page.tsx
@@ -6,17 +6,20 @@ import Card from '@/components/ui/Card';
 import Input from '@/components/ui/Input';
 import Select from '@/components/ui/Select';
 import Button from '@/components/ui/Button';
-import { useProdutos, unidadesMedida, categoriasProdutos } from '@/lib/produtosService';
+import { useProdutos } from '@/lib/produtosService';
+import { useUnidadesMedida } from '@/lib/unidadesService';
+import { useCategorias } from '@/lib/categoriasService';
 
 export default function EditarProdutoPage() {
   const params = useParams();
   const router = useRouter();
-  const { obterProdutoPorId, atualizarProduto } = useProdutos();
+  const { obterProdutoPorId, atualizarProduto, isLoading: produtosLoading } = useProdutos();
+  const { categorias } = useCategorias();
+  const { unidades } = useUnidadesMedida();
   const [isLoading, setIsLoading] = useState(false);
   const [mostrarInfoNutricional, setMostrarInfoNutricional] = useState(false);
   
   const produtoId = params.id as string;
-  const produtoOriginal = obterProdutoPorId(produtoId);
   
   const [produto, setProduto] = useState({
     nome: '',
@@ -41,34 +44,35 @@ export default function EditarProdutoPage() {
 
   // Carregar dados do produto
   useEffect(() => {
-    if (produtoOriginal) {
-      setProduto({
-        nome: produtoOriginal.nome,
-        categoria: produtoOriginal.categoria || '',
-        marca: produtoOriginal.marca || '',
-        unidadeMedida: produtoOriginal.unidadeMedida,
-        preco: produtoOriginal.preco?.toString() || '',
-        fornecedor: produtoOriginal.fornecedor,
-        infoNutricional: {
-          calorias: produtoOriginal.infoNutricional?.calorias?.toString() || '',
-          carboidratos: produtoOriginal.infoNutricional?.carboidratos?.toString() || '',
-          proteinas: produtoOriginal.infoNutricional?.proteinas?.toString() || '',
-          gordurasTotais: produtoOriginal.infoNutricional?.gordurasTotais?.toString() || '',
-          gordurasSaturadas: produtoOriginal.infoNutricional?.gordurasSaturadas?.toString() || '',
-          gordurasTrans: produtoOriginal.infoNutricional?.gordurasTrans?.toString() || '',
-          fibras: produtoOriginal.infoNutricional?.fibras?.toString() || '',
-          sodio: produtoOriginal.infoNutricional?.sodio?.toString() || ''
-        }
-      });
-      
-      setMostrarInfoNutricional(!!produtoOriginal.infoNutricional);
+    if (produtosLoading) return;
+    const original = obterProdutoPorId(produtoId);
+    if (!original) {
+      router.push('/produtos');
+      return;
     }
-  }, [produtoOriginal]);
+    setProduto({
+      nome: original.nome,
+      categoria: original.categoria || '',
+      marca: original.marca || '',
+      unidadeMedida: original.unidadeMedida,
+      preco: original.preco?.toString() || '',
+      fornecedor: original.fornecedor,
+      infoNutricional: {
+        calorias: original.infoNutricional?.calorias?.toString() || '',
+        carboidratos: original.infoNutricional?.carboidratos?.toString() || '',
+        proteinas: original.infoNutricional?.proteinas?.toString() || '',
+        gordurasTotais: original.infoNutricional?.gordurasTotais?.toString() || '',
+        gordurasSaturadas: original.infoNutricional?.gordurasSaturadas?.toString() || '',
+        gordurasTrans: original.infoNutricional?.gordurasTrans?.toString() || '',
+        fibras: original.infoNutricional?.fibras?.toString() || '',
+        sodio: original.infoNutricional?.sodio?.toString() || ''
+      }
+    });
+    setMostrarInfoNutricional(!!original.infoNutricional);
+  }, [produtosLoading, produtoId]);
 
-  // Redirecionar se o produto não existir
-  if (!produtoOriginal) {
-    router.push('/produtos');
-    return null;
+  if (produtosLoading) {
+    return <p>Carregando...</p>;
   }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -190,7 +194,7 @@ export default function EditarProdutoPage() {
                 name="categoria"
                 value={produto.categoria}
                 onChange={handleChange}
-                options={categoriasProdutos}
+                options={categorias.map(c => ({ value: c.id, label: c.nome }))}
                 error={erros.categoria}
               />
 
@@ -209,7 +213,7 @@ export default function EditarProdutoPage() {
                 name="unidadeMedida"
                 value={produto.unidadeMedida}
                 onChange={handleChange}
-                options={unidadesMedida}
+                options={unidades.map(u => ({ value: u.id, label: u.nome }))}
                 error={erros.unidadeMedida}
               />
               

--- a/src/app/produtos/novo/page.tsx
+++ b/src/app/produtos/novo/page.tsx
@@ -6,12 +6,16 @@ import Card from '@/components/ui/Card';
 import Input from '@/components/ui/Input';
 import Select from '@/components/ui/Select';
 import Button from '@/components/ui/Button';
-import { useProdutos, unidadesMedida, categoriasProdutos } from '@/lib/produtosService';
+import { useProdutos } from '@/lib/produtosService';
+import { useUnidadesMedida } from '@/lib/unidadesService';
+import { useCategorias } from '@/lib/categoriasService';
 import { useState } from 'react';
 
 export default function NovoProdutoPage() {
   const router = useRouter();
   const { adicionarProduto } = useProdutos();
+  const { categorias } = useCategorias();
+  const { unidades } = useUnidadesMedida();
   const [isLoading, setIsLoading] = useState(false);
   const [mostrarInfoNutricional, setMostrarInfoNutricional] = useState(false);
   
@@ -155,7 +159,7 @@ export default function NovoProdutoPage() {
                 name="categoria"
                 value={produto.categoria}
                 onChange={handleChange}
-                options={categoriasProdutos}
+                options={categorias.map(c => ({ value: c.id, label: c.nome }))}
                 error={erros.categoria}
               />
 
@@ -174,7 +178,7 @@ export default function NovoProdutoPage() {
                 name="unidadeMedida"
                 value={produto.unidadeMedida}
                 onChange={handleChange}
-                options={unidadesMedida}
+                options={unidades.map(u => ({ value: u.id, label: u.nome }))}
                 error={erros.unidadeMedida}
               />
               

--- a/src/app/relatorios/page.tsx
+++ b/src/app/relatorios/page.tsx
@@ -11,9 +11,10 @@ import Link from 'next/link';
 export default function RelatoriosPage() {
   const { 
     gerarRelatorioCompleto, 
-    gerarRelatorioCustos, 
-    gerarRelatorioIngredientes, 
-    gerarRelatorioReceitas 
+    gerarRelatorioCustos,
+    gerarRelatorioIngredientes,
+    gerarRelatorioReceitas,
+    gerarRelatorioEstoque
   } = useRelatorios();
   
   const [tipoRelatorio, setTipoRelatorio] = useState('completo');
@@ -43,6 +44,8 @@ export default function RelatoriosPage() {
         return renderizarRelatorioIngredientes();
       case 'receitas':
         return renderizarRelatorioReceitas();
+      case 'estoque':
+        return renderizarRelatorioEstoque();
       default:
         return renderizarRelatorioCompleto();
     }
@@ -298,6 +301,31 @@ export default function RelatoriosPage() {
       </div>
     );
   };
+
+  const renderizarRelatorioEstoque = () => {
+    const relatorio = gerarRelatorioEstoque();
+    return (
+      <div className="space-y-6">
+        <Card title="Estoque Atual">
+          {relatorio.itens.length > 0 ? (
+            <Table headers={['Produto', 'Quantidade', 'Preço', 'Valor Total']}>
+              {relatorio.itens.map(item => (
+                <TableRow key={item.id}>
+                  <TableCell>{item.nome}</TableCell>
+                  <TableCell>{item.quantidade}</TableCell>
+                  <TableCell>{formatarPreco(item.preco)}</TableCell>
+                  <TableCell>{formatarPreco(item.valorTotal)}</TableCell>
+                </TableRow>
+              ))}
+            </Table>
+          ) : (
+            <p className="text-gray-500 text-center py-4">Nenhum produto cadastrado</p>
+          )}
+          <p className="text-right font-medium mt-4">Total em estoque: {formatarPreco(relatorio.valorTotalEstoque)}</p>
+        </Card>
+      </div>
+    );
+  };
   
   const renderizarRelatorioReceitas = () => {
     const relatorio = gerarRelatorioReceitas();
@@ -360,6 +388,7 @@ export default function RelatoriosPage() {
                 { value: 'custos', label: 'Relatório de Custos' },
                 { value: 'ingredientes', label: 'Relatório de Ingredientes' },
                 { value: 'receitas', label: 'Relatório de Receitas' },
+                { value: 'estoque', label: 'Relatório de Estoque' },
               ]}
             />
           </div>

--- a/src/app/usuarios/novo/page.tsx
+++ b/src/app/usuarios/novo/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Card from '@/components/ui/Card';
+import Input from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+import { useUsuarios } from '@/lib/usuariosService';
+
+export default function NovoUsuarioPage() {
+  const router = useRouter();
+  const { registrarUsuario } = useUsuarios();
+  const [form, setForm] = useState({ nome: '', email: '', senha: '', confirmarSenha: '' });
+  const [erro, setErro] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (form.senha !== form.confirmarSenha) {
+      setErro('Senhas não conferem');
+      return;
+    }
+    registrarUsuario({ nome: form.nome, email: form.email, senha: form.senha });
+    router.push('/login');
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-100">
+      <Card className="w-96">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <h1 className="text-xl font-bold text-gray-800">Novo Usuário</h1>
+          {erro && <p className="text-sm text-red-600">{erro}</p>}
+          <Input label="Nome" name="nome" value={form.nome} onChange={handleChange} required />
+          <Input label="Email" type="email" name="email" value={form.email} onChange={handleChange} required />
+          <Input label="Senha" type="password" name="senha" value={form.senha} onChange={handleChange} required />
+          <Input label="Confirmar Senha" type="password" name="confirmarSenha" value={form.confirmarSenha} onChange={handleChange} required />
+          <Button type="submit" variant="primary" fullWidth>Cadastrar</Button>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,9 +2,11 @@
 
 import React, { useState } from 'react';
 import Link from 'next/link';
+import { useUsuarios } from '@/lib/usuariosService';
 
 const Header: React.FC = () => {
   const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const { usuarioAtual, logout } = useUsuarios();
 
   const toggleProfile = () => {
     setIsProfileOpen(!isProfileOpen);
@@ -14,7 +16,7 @@ const Header: React.FC = () => {
     <header className="bg-white border-b shadow-sm">
       <div className="flex items-center justify-between p-4">
         <div className="flex items-center">
-          <h2 className="text-xl font-semibold text-gray-800">Sistema de Gestão Gastronômica</h2>
+          <h2 className="text-xl font-semibold text-gray-800">Sistema de Controle - Fichas Técnicas</h2>
         </div>
 
         <div className="flex items-center space-x-4">
@@ -26,7 +28,7 @@ const Header: React.FC = () => {
               <div className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center">
                 <span className="text-sm font-medium text-gray-700">U</span>
               </div>
-              <span className="hidden md:block text-sm font-medium text-gray-700">Usuário</span>
+              <span className="hidden md:block text-sm font-medium text-gray-700">{usuarioAtual?.nome || 'Usuário'}</span>
             </button>
 
             {isProfileOpen && (
@@ -44,7 +46,8 @@ const Header: React.FC = () => {
                   Configurações
                 </Link>
                 <div className="border-t border-gray-100"></div>
-                <button 
+                <button
+                  onClick={logout}
                   className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                 >
                   Sair

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,25 +1,42 @@
 'use client';
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import Header from './Header';
 import Sidebar from './Sidebar';
+import { useUsuarios } from '@/lib/usuariosService';
+import { useRouter, usePathname } from 'next/navigation';
 
 interface MainLayoutProps {
   children: ReactNode;
 }
 
 const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
+  const { usuarioAtual } = useUsuarios();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!usuarioAtual && pathname !== '/login' && pathname !== '/usuarios/novo') {
+      router.push('/login');
+    }
+    if (usuarioAtual && (pathname === '/login' || pathname === '/usuarios/novo')) {
+      router.push('/');
+    }
+  }, [usuarioAtual, pathname, router]);
+
+  const hideLayout = pathname === '/login' || pathname === '/usuarios/novo';
+
   return (
     <div className="flex h-screen bg-gray-100">
-      <Sidebar />
+      {!hideLayout && <Sidebar />}
       <div className="flex flex-col flex-1 overflow-hidden">
-        <Header />
-        <main className="flex-1 overflow-y-auto p-4 md:p-6">
-          {children}
-        </main>
-        <footer className="bg-white p-4 text-center text-sm text-gray-500 border-t">
-          Sistema de Gestão Gastronômica &copy; {new Date().getFullYear()}
-        </footer>
+        {!hideLayout && <Header />}
+        <main className="flex-1 overflow-y-auto p-4 md:p-6">{children}</main>
+        {!hideLayout && (
+          <footer className="bg-white p-4 text-center text-sm text-gray-500 border-t">
+            Sistema de Controle - Fichas Técnicas &copy; {new Date().getFullYear()}
+          </footer>
+        )}
       </div>
     </div>
   );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -40,12 +40,21 @@ const Sidebar: React.FC = () => {
             </Link>
           </li>
           <li>
-            <Link 
+            <Link
               href="/produtos"
               className="flex items-center p-4 hover:bg-gray-700"
             >
               <span className="material-icons mr-3">inventory</span>
               {!isCollapsed && <span>Produtos</span>}
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/estoque"
+              className="flex items-center p-4 hover:bg-gray-700"
+            >
+              <span className="material-icons mr-3">store</span>
+              {!isCollapsed && <span>Estoque</span>}
             </Link>
           </li>
           <li>

--- a/src/lib/categoriasService.ts
+++ b/src/lib/categoriasService.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export interface CategoriaInfo {
+  id: string;
+  nome: string;
+}
+
+const gerarId = () => Date.now().toString(36) + Math.random().toString(36).substring(2);
+
+const salvarCategorias = (cats: CategoriaInfo[]) => {
+  localStorage.setItem('categoriasProdutos', JSON.stringify(cats));
+};
+
+const obterCategorias = (): CategoriaInfo[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const str = localStorage.getItem('categoriasProdutos');
+    return str ? JSON.parse(str) : [];
+  } catch (err) {
+    console.error('Erro ao ler categorias', err);
+    return [];
+  }
+};
+
+const categoriasPadrao: CategoriaInfo[] = [
+  { id: 'hortifruti', nome: 'Hortifruti' },
+  { id: 'carnes', nome: 'Carnes' },
+  { id: 'laticinios', nome: 'Laticínios' },
+  { id: 'graos', nome: 'Grãos e Cereais' },
+  { id: 'bebidas', nome: 'Bebidas' },
+  { id: 'temperos', nome: 'Temperos' },
+  { id: 'outros', nome: 'Outros' },
+];
+
+export const useCategorias = () => {
+  const [categorias, setCategorias] = useState<CategoriaInfo[]>([]);
+
+  useEffect(() => {
+    let cats = obterCategorias();
+    if (cats.length === 0) {
+      cats = categoriasPadrao;
+      salvarCategorias(cats);
+    }
+    setCategorias(cats);
+  }, []);
+
+  const adicionarCategoria = (nome: string) => {
+    const nova = { id: gerarId(), nome };
+    const novas = [...categorias, nova];
+    setCategorias(novas);
+    salvarCategorias(novas);
+    return nova;
+  };
+
+  const atualizarCategoria = (id: string, nome: string) => {
+    const atualizadas = categorias.map(c =>
+      c.id === id ? { ...c, nome } : c
+    );
+    setCategorias(atualizadas);
+    salvarCategorias(atualizadas);
+  };
+
+  const removerCategoria = (id: string) => {
+    const filtradas = categorias.filter(c => c.id !== id);
+    setCategorias(filtradas);
+    salvarCategorias(filtradas);
+  };
+
+  const obterCategoriaPorId = (id: string) => categorias.find(c => c.id === id);
+
+  return { categorias, adicionarCategoria, atualizarCategoria, removerCategoria, obterCategoriaPorId };
+};
+
+export const obterLabelCategoria = (id: string) => {
+  if (!id) return 'Não informado';
+  const cat = obterCategorias().find(c => c.id === id);
+  return cat ? cat.nome : id;
+};

--- a/src/lib/estoqueService.ts
+++ b/src/lib/estoqueService.ts
@@ -1,0 +1,124 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { obterProdutos, salvarProdutos, ProdutoInfo } from './produtosService';
+import {
+  useFichasTecnicas,
+  FichaTecnicaInfo,
+  IngredienteFicha
+} from './fichasTecnicasService';
+
+export interface MovimentacaoEstoque {
+  id: string;
+  produtoId: string;
+  quantidade: number;
+  preco?: number;
+  fornecedor?: string;
+  marca?: string;
+  data: string;
+  tipo: 'entrada' | 'saida';
+}
+
+const gerarId = () => {
+  return Date.now().toString(36) + Math.random().toString(36).substring(2);
+};
+
+const salvarMovimentacoes = (movs: MovimentacaoEstoque[]) => {
+  localStorage.setItem('movimentacoesEstoque', JSON.stringify(movs));
+};
+
+const obterMovimentacoes = (): MovimentacaoEstoque[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const str = localStorage.getItem('movimentacoesEstoque');
+    return str ? JSON.parse(str) : [];
+  } catch (err) {
+    console.error('Erro ao ler movimentacoes do localStorage', err);
+    return [];
+  }
+};
+
+export const useEstoque = () => {
+  const [movimentacoes, setMovimentacoes] = useState<MovimentacaoEstoque[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const { fichasTecnicas, atualizarFichaTecnica } = useFichasTecnicas();
+
+  useEffect(() => {
+    const armaz = obterMovimentacoes();
+    setMovimentacoes(armaz);
+    setIsLoading(false);
+  }, []);
+
+  const registrarEntrada = (dados: {
+    produtoId: string;
+    quantidade: number;
+    preco: number;
+    fornecedor: string;
+    marca?: string;
+  }) => {
+    const nova: MovimentacaoEstoque = { ...dados, id: gerarId(), data: new Date().toISOString(), tipo: 'entrada' };
+    const novas = [...movimentacoes, nova];
+    setMovimentacoes(novas);
+    salvarMovimentacoes(novas);
+
+    // Atualizar produto com novo preco/fornecedor/marca
+    const produtos = obterProdutos();
+      const atualizados = produtos.map((p: ProdutoInfo) =>
+        p.id === nova.produtoId
+          ? { ...p, preco: nova.preco as number, fornecedor: nova.fornecedor as string, marca: nova.marca || p.marca }
+          : p
+      );
+    salvarProdutos(atualizados);
+
+    // Atualizar fichas tecnicas que utilizam este produto
+    fichasTecnicas
+      .filter((f: FichaTecnicaInfo) =>
+        f.ingredientes.some((i: IngredienteFicha) => i.produtoId === nova.produtoId)
+      )
+      .forEach((f: FichaTecnicaInfo) => {
+        const dadosFicha = {
+          nome: f.nome,
+          descricao: f.descricao,
+          categoria: f.categoria,
+          ingredientes: f.ingredientes.map(
+            (i: IngredienteFicha) => ({ produtoId: i.produtoId, quantidade: i.quantidade })
+          ) as Omit<IngredienteFicha, 'custo' | 'id'>[],
+          modoPreparo: f.modoPreparo,
+          tempoPreparo: f.tempoPreparo,
+          rendimentoTotal: f.rendimentoTotal,
+          unidadeRendimento: f.unidadeRendimento,
+          observacoes: f.observacoes || ''
+        } as Omit<
+          FichaTecnicaInfo,
+          'id' | 'custoTotal' | 'custoPorcao' | 'infoNutricional' | 'infoNutricionalPorcao' | 'dataCriacao' | 'ultimaAtualizacao'
+        >;
+        atualizarFichaTecnica(f.id, dadosFicha);
+      });
+
+    return nova;
+  };
+
+  const registrarSaida = (dados: { produtoId: string; quantidade: number }) => {
+    const nova: MovimentacaoEstoque = {
+      id: gerarId(),
+      data: new Date().toISOString(),
+      tipo: 'saida',
+      produtoId: dados.produtoId,
+      quantidade: -Math.abs(dados.quantidade)
+    };
+    const novas = [...movimentacoes, nova];
+    setMovimentacoes(novas);
+    salvarMovimentacoes(novas);
+    return nova;
+  };
+
+  const obterHistoricoPorProduto = (produtoId: string) =>
+    movimentacoes.filter((m: MovimentacaoEstoque) => m.produtoId === produtoId);
+
+  const calcularEstoqueAtual = (produtoId: string) =>
+    movimentacoes
+      .filter((m: MovimentacaoEstoque) => m.produtoId === produtoId)
+      .reduce((total: number, m: MovimentacaoEstoque) => total + m.quantidade, 0);
+
+  return { movimentacoes, isLoading, registrarEntrada, registrarSaida, obterHistoricoPorProduto, calcularEstoqueAtual };
+};

--- a/src/lib/produtosService.ts
+++ b/src/lib/produtosService.ts
@@ -30,12 +30,12 @@ const gerarId = () => {
 };
 
 // Função para salvar produtos no localStorage
-const salvarProdutos = (produtos: ProdutoInfo[]) => {
+export const salvarProdutos = (produtos: ProdutoInfo[]) => {
   localStorage.setItem('produtos', JSON.stringify(produtos));
 };
 
 // Função para obter produtos do localStorage de forma segura
-const obterProdutos = (): ProdutoInfo[] => {
+export const obterProdutos = (): ProdutoInfo[] => {
   if (typeof window === 'undefined') return [];
 
   try {
@@ -99,7 +99,7 @@ export const useProdutos = () => {
       id,
     };
     
-    const novosProdutos = produtos.map(p => 
+    const novosProdutos = produtos.map((p: ProdutoInfo) =>
       p.id === id ? produtoAtualizado : p
     );
     
@@ -110,14 +110,14 @@ export const useProdutos = () => {
 
   // Remover produto
   const removerProduto = (id: string) => {
-    const novosProdutos = produtos.filter(p => p.id !== id);
+    const novosProdutos = produtos.filter((p: ProdutoInfo) => p.id !== id);
     setProdutos(novosProdutos);
     salvarProdutos(novosProdutos);
   };
 
   // Obter produto por ID
   const obterProdutoPorId = (id: string) => {
-    return produtos.find(p => p.id === id);
+    return produtos.find((p: ProdutoInfo) => p.id === id);
   };
 
   return {
@@ -130,16 +130,6 @@ export const useProdutos = () => {
   };
 };
 
-// Dados iniciais para unidades de medida
-export const unidadesMedida = [
-  { value: 'g', label: 'Gramas (g)' },
-  { value: 'kg', label: 'Quilogramas (kg)' },
-  { value: 'ml', label: 'Mililitros (ml)' },
-  { value: 'l', label: 'Litros (l)' },
-  { value: 'un', label: 'Unidade' },
-  { value: 'cx', label: 'Caixa' },
-  { value: 'pct', label: 'Pacote' },
-];
 
 // Categorias de produtos para classificacao em relatorios
 export const categoriasProdutos = [

--- a/src/lib/relatoriosService.ts
+++ b/src/lib/relatoriosService.ts
@@ -1,9 +1,12 @@
 'use client';
 
-import { useProdutos, obterLabelCategoria } from './produtosService';
+import { useProdutos, ProdutoInfo } from './produtosService';
+import { obterLabelCategoria } from './categoriasService';
+import { useEstoque } from './estoqueService';
 import {
   useFichasTecnicas,
-  obterLabelCategoriaReceita
+  obterLabelCategoriaReceita,
+  FichaTecnicaInfo
 } from './fichasTecnicasService';
 
 // Interface para dados de relatórios
@@ -30,6 +33,7 @@ export interface DadosRelatorio {
 export const useRelatorios = () => {
   const { produtos } = useProdutos();
   const { fichasTecnicas } = useFichasTecnicas();
+  const { calcularEstoqueAtual } = useEstoque();
   
   // Gerar relatório completo
   const gerarRelatorioCompleto = (): DadosRelatorio => {
@@ -38,22 +42,33 @@ export const useRelatorios = () => {
     const totalFichasTecnicas = fichasTecnicas.length;
     
     // Calcular custo total do estoque (considerando que não temos quantidade em estoque, apenas preço unitário)
-    const custoTotalEstoque = produtos.reduce((total, produto) => total + produto.preco, 0);
+    const custoTotalEstoque = produtos.reduce(
+      (total: number, produto: ProdutoInfo) => total + produto.preco,
+      0
+    );
     
     // Calcular custo médio por ficha técnica
-    const custoMedioPorFicha = fichasTecnicas.length > 0 
-      ? fichasTecnicas.reduce((total, ficha) => total + ficha.custoTotal, 0) / fichasTecnicas.length 
+    const custoMedioPorFicha = fichasTecnicas.length > 0
+      ? fichasTecnicas.reduce(
+          (total: number, ficha: FichaTecnicaInfo) => total + ficha.custoTotal,
+          0
+        ) / fichasTecnicas.length
       : 0;
     
     // Fichas técnicas ordenadas por custo (mais caras e mais baratas)
-    const fichasOrdenadasPorCusto = [...fichasTecnicas].sort((a, b) => b.custoTotal - a.custoTotal);
-    const fichasMaisCustos = fichasOrdenadasPorCusto.slice(0, 5).map(ficha => ({
+    const fichasOrdenadasPorCusto = [...fichasTecnicas].sort(
+      (a: FichaTecnicaInfo, b: FichaTecnicaInfo) => b.custoTotal - a.custoTotal
+    );
+    const fichasMaisCustos = fichasOrdenadasPorCusto.slice(0, 5).map((ficha: FichaTecnicaInfo) => ({
       id: ficha.id,
       nome: ficha.nome,
       custo: ficha.custoTotal
     }));
-    
-    const fichasMenosCustos = [...fichasOrdenadasPorCusto].reverse().slice(0, 5).map(ficha => ({
+
+    const fichasMenosCustos = [...fichasOrdenadasPorCusto]
+      .reverse()
+      .slice(0, 5)
+      .map((ficha: FichaTecnicaInfo) => ({
       id: ficha.id,
       nome: ficha.nome,
       custo: ficha.custoTotal
@@ -62,7 +77,7 @@ export const useRelatorios = () => {
     // Calcular ingredientes mais usados
     const contagemIngredientes: Record<string, {quantidade: number, ocorrencias: number}> = {};
     
-    fichasTecnicas.forEach(ficha => {
+    fichasTecnicas.forEach((ficha: FichaTecnicaInfo) => {
       ficha.ingredientes.forEach(ingrediente => {
         if (!contagemIngredientes[ingrediente.produtoId]) {
           contagemIngredientes[ingrediente.produtoId] = {
@@ -77,8 +92,8 @@ export const useRelatorios = () => {
     });
     
     const ingredientesMaisUsados = Object.entries(contagemIngredientes)
-      .map(([produtoId, dados]) => {
-        const produto = produtos.find(p => p.id === produtoId);
+      .map(([produtoId, dados]: [string, { quantidade: number; ocorrencias: number }]) => {
+        const produto = produtos.find((p: ProdutoInfo) => p.id === produtoId);
         return {
           id: produtoId,
           nome: produto ? produto.nome : 'Produto não encontrado',
@@ -87,12 +102,17 @@ export const useRelatorios = () => {
           ocorrencias: dados.ocorrencias
         };
       })
-      .sort((a, b) => b.ocorrencias - a.ocorrencias)
+      .sort(
+        (
+          a: { ocorrencias: number },
+          b: { ocorrencias: number }
+        ) => b.ocorrencias - a.ocorrencias
+      )
       .slice(0, 10);
     
     // Distribuição de categorias de produtos
     const categoriasProdutos: Record<string, number> = {};
-    produtos.forEach(produto => {
+    produtos.forEach((produto: ProdutoInfo) => {
       const categoria = produto.categoria || 'Não informado';
       if (!categoriasProdutos[categoria]) {
         categoriasProdutos[categoria] = 0;
@@ -101,15 +121,20 @@ export const useRelatorios = () => {
     });
     
     const distribuicaoCategoriasProdutos = Object.entries(categoriasProdutos)
-      .map(([categoria, quantidade]) => ({
+      .map(([categoria, quantidade]: [string, number]) => ({
         categoria: obterLabelCategoria(categoria),
         quantidade
       }))
-      .sort((a, b) => b.quantidade - a.quantidade);
+      .sort(
+        (
+          a: { quantidade: number },
+          b: { quantidade: number }
+        ) => b.quantidade - a.quantidade
+      );
     
     // Distribuição de categorias de receitas
     const categoriasReceitas: Record<string, number> = {};
-    fichasTecnicas.forEach(ficha => {
+    fichasTecnicas.forEach((ficha: FichaTecnicaInfo) => {
       const categoria = ficha.categoria;
       if (!categoriasReceitas[categoria]) {
         categoriasReceitas[categoria] = 0;
@@ -118,11 +143,16 @@ export const useRelatorios = () => {
     });
     
     const distribuicaoCategoriasReceitas = Object.entries(categoriasReceitas)
-      .map(([categoria, quantidade]) => ({
+      .map(([categoria, quantidade]: [string, number]) => ({
         categoria: obterLabelCategoriaReceita(categoria),
         quantidade
       }))
-      .sort((a, b) => b.quantidade - a.quantidade);
+      .sort(
+        (
+          a: { quantidade: number },
+          b: { quantidade: number }
+        ) => b.quantidade - a.quantidade
+      );
     
     return {
       totalProdutos,
@@ -158,6 +188,21 @@ export const useRelatorios = () => {
       distribuicaoCategoriasProdutos: relatorioCompleto.distribuicaoCategoriasProdutos
     };
   };
+
+  const gerarRelatorioEstoque = () => {
+    const itens = produtos.map((p: ProdutoInfo) => {
+      const qtd = calcularEstoqueAtual(p.id);
+      return {
+        id: p.id,
+        nome: p.nome,
+        quantidade: qtd,
+        preco: p.preco,
+        valorTotal: qtd * p.preco
+      };
+    });
+    const valorTotalEstoque = itens.reduce((t, i) => t + i.valorTotal, 0);
+    return { itens, valorTotalEstoque };
+  };
   
   // Gerar relatório de receitas
   const gerarRelatorioReceitas = () => {
@@ -173,6 +218,7 @@ export const useRelatorios = () => {
     gerarRelatorioCompleto,
     gerarRelatorioCustos,
     gerarRelatorioIngredientes,
-    gerarRelatorioReceitas
+    gerarRelatorioReceitas,
+    gerarRelatorioEstoque
   };
 };

--- a/src/lib/unidadesService.ts
+++ b/src/lib/unidadesService.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export interface UnidadeInfo {
+  id: string; // sigla da unidade ex: kg, g
+  nome: string; // nome legivel
+}
+
+const gerarId = () =>
+  Date.now().toString(36) + Math.random().toString(36).substring(2);
+
+const salvarUnidades = (dados: UnidadeInfo[]) => {
+  localStorage.setItem('unidadesMedida', JSON.stringify(dados));
+};
+
+const obterUnidades = (): UnidadeInfo[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const str = localStorage.getItem('unidadesMedida');
+    return str ? JSON.parse(str) : [];
+  } catch (err) {
+    console.error('Erro ao ler unidades', err);
+    return [];
+  }
+};
+
+const unidadesPadrao: UnidadeInfo[] = [
+  { id: 'g', nome: 'Gramas (g)' },
+  { id: 'kg', nome: 'Quilogramas (kg)' },
+  { id: 'ml', nome: 'Mililitros (ml)' },
+  { id: 'l', nome: 'Litros (l)' },
+  { id: 'un', nome: 'Unidade' },
+  { id: 'cx', nome: 'Caixa' },
+  { id: 'pct', nome: 'Pacote' },
+];
+
+export const useUnidadesMedida = () => {
+  const [unidades, setUnidades] = useState<UnidadeInfo[]>([]);
+
+  useEffect(() => {
+    let atual = obterUnidades();
+    if (atual.length === 0) {
+      atual = unidadesPadrao;
+      salvarUnidades(atual);
+    }
+    setUnidades(atual);
+  }, []);
+
+  const adicionarUnidade = (id: string, nome: string) => {
+    const nova = { id, nome };
+    const novas = [...unidades, nova];
+    setUnidades(novas);
+    salvarUnidades(novas);
+    return nova;
+  };
+
+  const atualizarUnidade = (id: string, nome: string) => {
+    const atualizadas = unidades.map(u => (u.id === id ? { ...u, nome } : u));
+    setUnidades(atualizadas);
+    salvarUnidades(atualizadas);
+  };
+
+  const removerUnidade = (id: string) => {
+    const filtradas = unidades.filter(u => u.id !== id);
+    setUnidades(filtradas);
+    salvarUnidades(filtradas);
+  };
+
+  const obterUnidadePorId = (id: string) => unidades.find(u => u.id === id);
+
+  return {
+    unidades,
+    adicionarUnidade,
+    atualizarUnidade,
+    removerUnidade,
+    obterUnidadePorId,
+  };
+};
+
+export const obterLabelUnidade = (id: string) => {
+  if (!id) return 'Não informado';
+  const unidade = obterUnidades().find(u => u.id === id);
+  return unidade ? unidade.nome : id;
+};

--- a/src/lib/usuariosService.ts
+++ b/src/lib/usuariosService.ts
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { createHash } from 'crypto';
+
+export interface UsuarioInfo {
+  id: string;
+  nome: string;
+  email: string;
+  senhaHash: string;
+}
+
+const gerarId = () => {
+  return Date.now().toString(36) + Math.random().toString(36).substring(2);
+};
+
+const hashSenha = (senha: string) => {
+  return createHash('sha256').update(senha).digest('hex');
+};
+
+const salvarUsuarios = (usuarios: UsuarioInfo[]) => {
+  localStorage.setItem('usuarios', JSON.stringify(usuarios));
+};
+
+const obterUsuarios = (): UsuarioInfo[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const usuariosString = localStorage.getItem('usuarios');
+    return usuariosString ? JSON.parse(usuariosString) : [];
+  } catch (err) {
+    console.error('Erro ao ler usuarios do localStorage', err);
+    return [];
+  }
+};
+
+export const useUsuarios = () => {
+  const [usuarios, setUsuarios] = useState<UsuarioInfo[]>(() => obterUsuarios());
+  const [usuarioAtual, setUsuarioAtual] = useState<UsuarioInfo | null>(() => {
+    if (typeof window === 'undefined') return null;
+    const armazenados = obterUsuarios();
+    const idLogado = localStorage.getItem('usuarioLogado');
+    return idLogado ? armazenados.find(u => u.id === idLogado) || null : null;
+  });
+
+  useEffect(() => {
+    const armazenados = obterUsuarios();
+    setUsuarios(armazenados);
+    const idLogado = localStorage.getItem('usuarioLogado');
+    if (idLogado) {
+      const encontrado = armazenados.find(u => u.id === idLogado) || null;
+      setUsuarioAtual(encontrado);
+    }
+  }, []);
+
+  const registrarUsuario = (dados: { nome: string; email: string; senha: string }) => {
+    const novo = {
+      id: gerarId(),
+      nome: dados.nome,
+      email: dados.email,
+      senhaHash: hashSenha(dados.senha)
+    };
+    const novos = [...usuarios, novo];
+    setUsuarios(novos);
+    salvarUsuarios(novos);
+    return novo;
+  };
+
+  const removerUsuario = (id: string) => {
+    const filtrados = usuarios.filter(u => u.id !== id);
+    setUsuarios(filtrados);
+    salvarUsuarios(filtrados);
+    const idLogado = localStorage.getItem('usuarioLogado');
+    if (idLogado === id) {
+      logout();
+    }
+  };
+
+  const alterarSenha = (id: string, novaSenha: string) => {
+    const atualizados = usuarios.map(u =>
+      u.id === id ? { ...u, senhaHash: hashSenha(novaSenha) } : u
+    );
+    setUsuarios(atualizados);
+    salvarUsuarios(atualizados);
+    if (usuarioAtual?.id === id) {
+      const atualizado = atualizados.find(u => u.id === id) || null;
+      setUsuarioAtual(atualizado);
+    }
+  };
+
+  const login = (email: string, senha: string) => {
+    const usuario = usuarios.find(u => u.email === email && u.senhaHash === hashSenha(senha));
+    if (usuario) {
+      setUsuarioAtual(usuario);
+      localStorage.setItem('usuarioLogado', usuario.id);
+      return usuario;
+    }
+    return null;
+  };
+
+  const logout = () => {
+    setUsuarioAtual(null);
+    localStorage.removeItem('usuarioLogado');
+  };
+
+  return { usuarios, usuarioAtual, registrarUsuario, login, logout, removerUsuario, alterarSenha };
+};


### PR DESCRIPTION
## Summary
- add configurable units of measure
- fix product edit state loop
- convert ingredient costs between units
- allow editing and selecting units on technical sheets
- document unit management in the manual

## Testing
- `npx tsc --noEmit`
- `npx eslint .` *(with warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841dbe48d088321bfcec262ed1701e4