### PR TITLE
Add user profile and UI improvements

### DIFF
--- a/docs/melhorias-sistema.md
+++ b/docs/melhorias-sistema.md
@@ -1,0 +1,72 @@
+# Análise de Melhorias
+
+Este documento apresenta pontos de melhoria identificados no projeto CustoChef após
+uma revisão geral do código-fonte.
+
+## 1. Sistema de Perfis de Usuário
+
+O controle de usuários é realizado no cliente através do hook `useUsuarios`
+(`src/lib/usuariosService.ts`), que guarda os dados no `localStorage` e utiliza
+hashing SHA-256. Embora simples, esse modelo possui limitações:
+
+- Não há validação de email único ou reforço de senha.
+- Os perfis são restritos a `admin` e `viewer`, podendo ser ampliados.
+- Não existe backend para centralizar os dados, dificultando escalabilidade.
+
+**Sugestões**:
+
+1. Implementar autenticação baseada em servidor (por exemplo, API REST ou
+   integração com NextAuth) para persistência segura.
+2. Adicionar níveis de acesso adicionais e telas de gerenciamento com filtros e
+   pesquisa.
+3. Aplicar validações de senha forte e confirmação de email durante o
+   cadastramento.
+
+Referências de código:
+- Definição do hook `useUsuarios`【F:src/lib/usuariosService.ts†L1-L75】
+- Formulário de cadastro de usuário【F:src/app/usuarios/novo/page.tsx†L1-L37】
+
+## 2. Configurações
+
+As páginas de configuração (categorias, unidades, usuários) seguem estrutura
+similar com modais para criação/edição. Pontos de melhoria:
+
+- Falta paginação ou busca para grandes listas.
+- Não há opção de exportar/importar as configurações.
+- A navegação poderia ser centralizada em uma barra lateral ou abas internas.
+
+**Sugestões**:
+
+1. Adicionar filtros e pesquisa nas tabelas (ex.: `CategoriasConfigPage`).
+2. Permitir exportar configurações para JSON e importar de arquivos.
+3. Consolidar as páginas em um layout de abas para facilitar a navegação.
+
+Exemplo de estrutura atual【F:src/app/configuracoes/page.tsx†L1-L34】.
+
+## 3. Modernização do Dashboard
+
+O Dashboard apresenta cartões com números e listas simples. Para
+uma visualização mais moderna e clara, recomenda-se:
+
+- Inserir gráficos (barras, pizza) para as distribuições de categorias.
+- Utilizar componentes de cards com ícones e cores de destaque.
+- Aplicar responsividade e animações sutis para melhorar a experiência.
+
+Trecho da página atual do Dashboard【F:src/app/page.tsx†L1-L117】.
+
+## 4. Revisão Geral das Telas
+
+- Páginas como `Unidades de Medida` e `Categorias` se repetem em layout e podem
+  compartilhar componentes reutilizáveis para formulários.
+- O uso de `alert()` para feedback (ex.: troca de senha em
+  `PerfilPage`) pode ser substituído por um sistema de notificações.
+- Incluir mensagens de erro ou carregamento consistentes em todas as telas.
+
+Exemplo de uso de `alert()` no perfil【F:src/app/configuracoes/perfil/page.tsx†L21-L24】.
+
+## Conclusão
+
+O projeto está bem organizado em termos de estrutura de pastas e componentes,
+mas pode evoluir em segurança, UX e escalabilidade. A adoção de um backend para
+autenticação, melhorias na navegação de configurações e enriquecimento visual do
+Dashboard são passos importantes para tornar o sistema mais profissional.

--- a/src/app/configuracoes/categorias/page.tsx
+++ b/src/app/configuracoes/categorias/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 import Button from '@/components/ui/Button';
 import Modal, { useModal } from '@/components/ui/Modal';
@@ -13,6 +13,8 @@ export default function CategoriasConfigPage() {
   const { isOpen: isEditOpen, openModal: openEdit, closeModal: closeEdit } = useModal();
   const [nova, setNova] = useState('');
   const [editar, setEditar] = useState({ id: '', nome: '' });
+  const [filtro, setFiltro] = useState('');
+  const fileInput = useRef<HTMLInputElement>(null);
 
   const handleAdd = (e: React.FormEvent) => {
     e.preventDefault();
@@ -32,12 +34,50 @@ export default function CategoriasConfigPage() {
     closeEdit();
   };
 
+  const handleExport = () => {
+    const data = JSON.stringify(categorias, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'categorias.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport: React.ChangeEventHandler<HTMLInputElement> = e => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result as string) as { nome: string }[];
+        data.forEach(d => d.nome && adicionarCategoria(d.nome));
+      } catch (err) {
+        console.error('Erro ao importar categorias', err);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const filtradas = categorias.filter(c =>
+    c.nome.toLowerCase().includes(filtro.toLowerCase())
+  );
+
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold text-gray-800">Categorias de Produtos</h1>
-      <Button onClick={openModal} variant="primary">Nova Categoria</Button>
+      <div className="flex flex-wrap items-end gap-2">
+        <Button onClick={openModal} variant="primary">Nova Categoria</Button>
+        <Button onClick={handleExport} variant="secondary">Exportar JSON</Button>
+        <Button onClick={() => fileInput.current?.click()} variant="secondary">Importar JSON</Button>
+        <div className="flex-1 min-w-[150px]">
+          <Input label="Buscar" value={filtro} onChange={e => setFiltro(e.target.value)} />
+        </div>
+      </div>
+      <input type="file" ref={fileInput} className="hidden" accept="application/json" onChange={handleImport} />
       <Table headers={["Nome", "Ações"]}>
-        {categorias.map(cat => (
+        {filtradas.map(cat => (
           <TableRow key={cat.id}>
             <TableCell>{cat.nome}</TableCell>
             <TableCell className="flex items-center space-x-2">

--- a/src/app/configuracoes/perfil/page.tsx
+++ b/src/app/configuracoes/perfil/page.tsx
@@ -1,14 +1,22 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Input from '@/components/ui/Input';
 import Button from '@/components/ui/Button';
+import Toast from '@/components/ui/Toast';
 import { useUsuarios } from '@/lib/usuariosService';
 
 export default function PerfilPage() {
   const { usuarioAtual, alterarSenha } = useUsuarios();
   const [senhaForm, setSenhaForm] = useState({ senha: '', confirmar: '' });
   const [erro, setErro] = useState('');
+  const [toast, setToast] = useState('');
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   if (!usuarioAtual) return <p className="p-4">Nenhum usuário logado.</p>;
 
@@ -21,16 +29,24 @@ export default function PerfilPage() {
     alterarSenha(usuarioAtual.id, senhaForm.senha);
     setSenhaForm({ senha: '', confirmar: '' });
     setErro('');
-    alert('Senha alterada');
+    setToast('Senha alterada');
   };
 
   return (
     <div className="space-y-4">
+      <Toast message={toast} onClose={() => setToast('')} />
       <h1 className="text-2xl font-bold text-gray-800">Perfil</h1>
       <div className="space-y-2">
         <p><strong>Nome:</strong> {usuarioAtual.nome}</p>
         <p><strong>Email:</strong> {usuarioAtual.email}</p>
-        <p><strong>Perfil:</strong> {usuarioAtual.role === 'admin' ? 'Administrador' : 'Visualizador'}</p>
+        <p>
+          <strong>Perfil:</strong>{' '}
+          {usuarioAtual.role === 'admin'
+            ? 'Administrador'
+            : usuarioAtual.role === 'editor'
+            ? 'Editor'
+            : 'Visualizador'}
+        </p>
       </div>
       <form onSubmit={handleSenha} className="space-y-2 max-w-sm">
         {erro && <p className="text-sm text-red-600">{erro}</p>}

--- a/src/app/configuracoes/usuarios/page.tsx
+++ b/src/app/configuracoes/usuarios/page.tsx
@@ -11,7 +11,7 @@ export default function UsuariosConfigPage() {
   const { usuarios, registrarUsuario, removerUsuario, alterarSenha } = useUsuarios();
   const { isOpen, openModal, closeModal } = useModal();
   const { isOpen: isSenhaOpen, openModal: openSenhaModal, closeModal: closeSenhaModal } = useModal();
-  const [novo, setNovo] = useState<{ nome: string; email: string; senha: string; confirmarSenha: string; role: 'admin' | 'viewer' }>({ nome: '', email: '', senha: '', confirmarSenha: '', role: 'viewer' });
+  const [novo, setNovo] = useState<{ nome: string; email: string; senha: string; confirmarSenha: string; role: 'admin' | 'editor' | 'viewer' }>({ nome: '', email: '', senha: '', confirmarSenha: '', role: 'viewer' });
   const [erro, setErro] = useState('');
   const [senhaForm, setSenhaForm] = useState({ id: '', senha: '', confirmarSenha: '' });
   const [erroSenha, setErroSenha] = useState('');
@@ -22,7 +22,11 @@ export default function UsuariosConfigPage() {
       setErro('Senhas não conferem');
       return;
     }
-    registrarUsuario({ nome: novo.nome, email: novo.email, senha: novo.senha, role: novo.role });
+    const criado = registrarUsuario({ nome: novo.nome, email: novo.email, senha: novo.senha, role: novo.role });
+    if (!criado) {
+      setErro('Email já cadastrado ou senha fraca');
+      return;
+    }
     setNovo({ nome: '', email: '', senha: '', confirmarSenha: '', role: 'viewer' });
     setErro('');
     closeModal();
@@ -53,7 +57,9 @@ export default function UsuariosConfigPage() {
           <TableRow key={u.id}>
             <TableCell>{u.nome}</TableCell>
             <TableCell>{u.email}</TableCell>
-            <TableCell>{u.role === 'admin' ? 'Administrador' : 'Visualizador'}</TableCell>
+            <TableCell>
+              {u.role === 'admin' ? 'Administrador' : u.role === 'editor' ? 'Editor' : 'Visualizador'}
+            </TableCell>
             <TableCell className="flex items-center space-x-2">
               <Button size="sm" variant="secondary" onClick={() => iniciarAlterarSenha(u.id)}>
                 Alterar Senha
@@ -78,9 +84,10 @@ export default function UsuariosConfigPage() {
             <select
               className="border border-[var(--cor-borda)] rounded-md p-2 w-full"
               value={novo.role}
-              onChange={e => setNovo({ ...novo, role: e.target.value as 'admin' | 'viewer' })}
+              onChange={e => setNovo({ ...novo, role: e.target.value as 'admin' | 'editor' | 'viewer' })}
             >
               <option value="viewer">Visualizador</option>
+              <option value="editor">Editor</option>
               <option value="admin">Administrador</option>
             </select>
           </div>

--- a/src/app/fichas-tecnicas/[id]/editar/page.tsx
+++ b/src/app/fichas-tecnicas/[id]/editar/page.tsx
@@ -14,6 +14,7 @@ import { useUnidadesMedida } from '@/lib/unidadesService';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 import { useModal } from '@/components/ui/Modal';
 import Modal from '@/components/ui/Modal';
+import Toast from '@/components/ui/Toast';
 
 type Ingrediente = Omit<IngredienteFicha, 'id' | 'custo'>;
 
@@ -41,6 +42,7 @@ export default function EditarFichaTecnicaPage() {
   const { unidades } = useUnidadesMedida();
   const { categorias } = useCategoriasReceita();
   const [isSaving, setIsSaving] = useState(false);
+  const [toast, setToast] = useState('');
   
   const fichaId = params.id as string;
   const fichaOriginal = obterFichaTecnicaPorId(fichaId);
@@ -79,6 +81,12 @@ export default function EditarFichaTecnicaPage() {
   });
 
   const [erros, setErros] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   useEffect(() => {
     if (!fichaTecnica.unidadeRendimento) return;
@@ -255,7 +263,7 @@ export default function EditarFichaTecnicaPage() {
       router.push(`/fichas-tecnicas/${fichaId}`);
     } catch (error) {
       console.error('Erro ao atualizar ficha técnica:', error);
-      alert('Ocorreu um erro ao atualizar a ficha técnica. Tente novamente.');
+      setToast('Erro ao atualizar ficha técnica');
     } finally {
       setIsSaving(false);
     }
@@ -275,6 +283,7 @@ export default function EditarFichaTecnicaPage() {
 
   return (
     <div className="space-y-6">
+      <Toast message={toast} onClose={() => setToast('')} />
       <h1 className="text-2xl font-bold text-gray-800">Editar Ficha Técnica</h1>
       
       <form onSubmit={handleSubmit}>

--- a/src/app/fichas-tecnicas/nova/page.tsx
+++ b/src/app/fichas-tecnicas/nova/page.tsx
@@ -14,6 +14,7 @@ import { useUnidadesMedida } from '@/lib/unidadesService';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 import { useModal } from '@/components/ui/Modal';
 import Modal from '@/components/ui/Modal';
+import Toast from '@/components/ui/Toast';
 
 type Ingrediente = Omit<IngredienteFicha, 'id' | 'custo'>;
 
@@ -36,6 +37,7 @@ export default function NovaFichaTecnicaPage() {
   const { unidades } = useUnidadesMedida();
   const { categorias } = useCategoriasReceita();
   const [isLoading, setIsLoading] = useState(false);
+  const [toast, setToast] = useState('');
 
   
   // Modal para adicionar ingredientes
@@ -78,6 +80,12 @@ export default function NovaFichaTecnicaPage() {
   }, [fichaTecnica.ingredientes, fichaTecnica.unidadeRendimento]);
 
   const [erros, setErros] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   // Manipular mudanças nos campos da ficha técnica
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
@@ -210,7 +218,7 @@ export default function NovaFichaTecnicaPage() {
       router.push('/fichas-tecnicas');
     } catch (error) {
       console.error('Erro ao salvar ficha técnica:', error);
-      alert('Ocorreu um erro ao salvar a ficha técnica. Tente novamente.');
+      setToast('Erro ao salvar ficha técnica');
     } finally {
       setIsLoading(false);
     }
@@ -230,6 +238,7 @@ export default function NovaFichaTecnicaPage() {
 
   return (
     <div className="space-y-6">
+      <Toast message={toast} onClose={() => setToast('')} />
       <h1 className="text-2xl font-bold text-gray-800">Nova Ficha Técnica</h1>
       
       <form onSubmit={handleSubmit}>

--- a/src/app/produtos/[id]/editar/page.tsx
+++ b/src/app/produtos/[id]/editar/page.tsx
@@ -9,6 +9,7 @@ import Button from '@/components/ui/Button';
 import { useProdutos } from '@/lib/produtosService';
 import { useUnidadesMedida } from '@/lib/unidadesService';
 import { useCategorias } from '@/lib/categoriasService';
+import Toast from '@/components/ui/Toast';
 
 export default function EditarInsumoPage() {
   const params = useParams();
@@ -18,6 +19,13 @@ export default function EditarInsumoPage() {
   const { unidades } = useUnidadesMedida();
   const [isLoading, setIsLoading] = useState(false);
   const [mostrarInfoNutricional, setMostrarInfoNutricional] = useState(false);
+  const [toast, setToast] = useState('');
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
   
   const produtoId = params.id as string;
   
@@ -171,7 +179,7 @@ export default function EditarInsumoPage() {
       router.push(`/produtos/${produtoId}`);
     } catch (error) {
       console.error('Erro ao atualizar produto:', error);
-      alert('Ocorreu um erro ao atualizar o produto. Tente novamente.');
+      setToast('Erro ao atualizar produto');
     } finally {
       setIsLoading(false);
     }
@@ -179,6 +187,7 @@ export default function EditarInsumoPage() {
 
   return (
     <div className="space-y-6">
+      <Toast message={toast} onClose={() => setToast('')} />
       <h1 className="text-2xl font-bold text-gray-800">Editar Insumo</h1>
       
       <form onSubmit={handleSubmit}>

--- a/src/app/produtos/novo/page.tsx
+++ b/src/app/produtos/novo/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';
 import Input from '@/components/ui/Input';
@@ -9,7 +9,7 @@ import Button from '@/components/ui/Button';
 import { useProdutos } from '@/lib/produtosService';
 import { useUnidadesMedida } from '@/lib/unidadesService';
 import { useCategorias } from '@/lib/categoriasService';
-import { useState } from 'react';
+import Toast from '@/components/ui/Toast';
 
 export default function NovoInsumoPage() {
   const router = useRouter();
@@ -18,6 +18,13 @@ export default function NovoInsumoPage() {
   const { unidades } = useUnidadesMedida();
   const [isLoading, setIsLoading] = useState(false);
   const [mostrarInfoNutricional, setMostrarInfoNutricional] = useState(false);
+  const [toast, setToast] = useState('');
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
   
   const [produto, setProduto] = useState({
     nome: '',
@@ -135,7 +142,7 @@ export default function NovoInsumoPage() {
       router.push('/produtos');
     } catch (error) {
       console.error('Erro ao salvar produto:', error);
-      alert('Ocorreu um erro ao salvar o produto. Tente novamente.');
+      setToast('Erro ao salvar produto');
     } finally {
       setIsLoading(false);
     }
@@ -143,6 +150,7 @@ export default function NovoInsumoPage() {
 
   return (
     <div className="space-y-6">
+      <Toast message={toast} onClose={() => setToast('')} />
       <h1 className="text-2xl font-bold text-gray-800">Novo Insumo</h1>
       
       <form onSubmit={handleSubmit}>

--- a/src/app/usuarios/novo/page.tsx
+++ b/src/app/usuarios/novo/page.tsx
@@ -11,10 +11,10 @@ import Logo from '@/components/ui/Logo';
 export default function NovoUsuarioPage() {
   const router = useRouter();
   const { registrarUsuario } = useUsuarios();
-  const [form, setForm] = useState({ nome: '', email: '', senha: '', confirmarSenha: '' });
+  const [form, setForm] = useState({ nome: '', email: '', senha: '', confirmarSenha: '', role: 'viewer' });
   const [erro, setErro] = useState('');
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
@@ -24,7 +24,11 @@ export default function NovoUsuarioPage() {
       setErro('Senhas não conferem');
       return;
     }
-    registrarUsuario({ nome: form.nome, email: form.email, senha: form.senha, role: 'viewer' });
+    const criado = registrarUsuario({ nome: form.nome, email: form.email, senha: form.senha, role: form.role as 'admin' | 'editor' | 'viewer' });
+    if (!criado) {
+      setErro('Email já cadastrado ou senha fraca');
+      return;
+    }
     router.push('/login');
   };
 
@@ -41,6 +45,19 @@ export default function NovoUsuarioPage() {
           <Input label="Email" type="email" name="email" value={form.email} onChange={handleChange} required />
           <Input label="Senha" type="password" name="senha" value={form.senha} onChange={handleChange} required />
           <Input label="Confirmar Senha" type="password" name="confirmarSenha" value={form.confirmarSenha} onChange={handleChange} required />
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Perfil</label>
+            <select
+              name="role"
+              value={form.role}
+              onChange={handleChange}
+              className="border border-[var(--cor-borda)] rounded-md p-2 w-full"
+            >
+              <option value="viewer">Visualizador</option>
+              <option value="editor">Editor</option>
+              <option value="admin">Administrador</option>
+            </select>
+          </div>
           <Button type="submit" variant="primary" fullWidth>Cadastrar</Button>
         </form>
       </Card>

--- a/src/lib/usuariosService.ts
+++ b/src/lib/usuariosService.ts
@@ -8,7 +8,7 @@ export interface UsuarioInfo {
   nome: string;
   email: string;
   senhaHash: string;
-  role: 'admin' | 'viewer';
+  role: 'admin' | 'editor' | 'viewer';
 }
 
 const gerarId = () => {
@@ -54,14 +54,22 @@ export const useUsuarios = () => {
     }
   }, []);
 
-  const registrarUsuario = (dados: { nome: string; email: string; senha: string; role?: 'admin' | 'viewer' }) => {
+  const senhaForte = (senha: string) => /^(?=.*[a-zA-Z])(?=.*\d).{6,}$/.test(senha);
+
+  const registrarUsuario = (dados: { nome: string; email: string; senha: string; role?: 'admin' | 'editor' | 'viewer' }) => {
+    if (usuarios.some(u => u.email === dados.email)) {
+      return null;
+    }
+    if (!senhaForte(dados.senha)) {
+      return null;
+    }
     const novo = {
       id: gerarId(),
       nome: dados.nome,
       email: dados.email,
       senhaHash: hashSenha(dados.senha),
       role: dados.role || 'viewer'
-    };
+    } as UsuarioInfo;
     const novos = [...usuarios, novo];
     setUsuarios(novos);
     salvarUsuarios(novos);


### PR DESCRIPTION
## Summary
- enhance user service with new roles and validation
- improve user creation flow
- add search and import/export to category config page
- replace alert feedback with Toast notifications across pages
- show editor role correctly on user profile page

## Testing
- `npm install` *(failed: Service Unavailable 503)*
- `npm run lint` *(failed: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b19b90c50832195af0d176366f85a