### PR TITLE
Add profile editing and UI tweaks

### DIFF
--- a/docs/melhorias-sistema.md
+++ b/docs/melhorias-sistema.md
@@ -1,0 +1,72 @@
+# Análise de Melhorias
+
+Este documento apresenta pontos de melhoria identificados no projeto CustoChef após
+uma revisão geral do código-fonte.
+
+## 1. Sistema de Perfis de Usuário
+
+O controle de usuários é realizado no cliente através do hook `useUsuarios`
+(`src/lib/usuariosService.ts`), que guarda os dados no `localStorage` e utiliza
+hashing SHA-256. Embora simples, esse modelo possui limitações:
+
+- Não há validação de email único ou reforço de senha.
+- Os perfis são restritos a `admin` e `viewer`, podendo ser ampliados.
+- Não existe backend para centralizar os dados, dificultando escalabilidade.
+
+**Sugestões**:
+
+1. Implementar autenticação baseada em servidor (por exemplo, API REST ou
+   integração com NextAuth) para persistência segura.
+2. Adicionar níveis de acesso adicionais e telas de gerenciamento com filtros e
+   pesquisa.
+3. Aplicar validações de senha forte e confirmação de email durante o
+   cadastramento.
+
+Referências de código:
+- Definição do hook `useUsuarios`【F:src/lib/usuariosService.ts†L1-L75】
+- Formulário de cadastro de usuário【F:src/app/usuarios/novo/page.tsx†L1-L37】
+
+## 2. Configurações
+
+As páginas de configuração (categorias, unidades, usuários) seguem estrutura
+similar com modais para criação/edição. Pontos de melhoria:
+
+- Falta paginação ou busca para grandes listas.
+- Não há opção de exportar/importar as configurações.
+- A navegação poderia ser centralizada em uma barra lateral ou abas internas.
+
+**Sugestões**:
+
+1. Adicionar filtros e pesquisa nas tabelas (ex.: `CategoriasConfigPage`).
+2. Permitir exportar configurações para JSON e importar de arquivos.
+3. Consolidar as páginas em um layout de abas para facilitar a navegação.
+
+Exemplo de estrutura atual【F:src/app/configuracoes/page.tsx†L1-L34】.
+
+## 3. Modernização do Dashboard
+
+O Dashboard apresenta cartões com números e listas simples. Para
+uma visualização mais moderna e clara, recomenda-se:
+
+- Inserir gráficos (barras, pizza) para as distribuições de categorias.
+- Utilizar componentes de cards com ícones e cores de destaque.
+- Aplicar responsividade e animações sutis para melhorar a experiência.
+
+Trecho da página atual do Dashboard【F:src/app/page.tsx†L1-L117】.
+
+## 4. Revisão Geral das Telas
+
+- Páginas como `Unidades de Medida` e `Categorias` se repetem em layout e podem
+  compartilhar componentes reutilizáveis para formulários.
+- O uso de `alert()` para feedback (ex.: troca de senha em
+  `PerfilPage`) pode ser substituído por um sistema de notificações.
+- Incluir mensagens de erro ou carregamento consistentes em todas as telas.
+
+Exemplo de uso de `alert()` no perfil【F:src/app/configuracoes/perfil/page.tsx†L21-L24】.
+
+## Conclusão
+
+O projeto está bem organizado em termos de estrutura de pastas e componentes,
+mas pode evoluir em segurança, UX e escalabilidade. A adoção de um backend para
+autenticação, melhorias na navegação de configurações e enriquecimento visual do
+Dashboard são passos importantes para tornar o sistema mais profissional.

--- a/src/app/configuracoes/categorias/page.tsx
+++ b/src/app/configuracoes/categorias/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 import Button from '@/components/ui/Button';
 import Modal, { useModal } from '@/components/ui/Modal';
@@ -13,6 +13,8 @@ export default function CategoriasConfigPage() {
   const { isOpen: isEditOpen, openModal: openEdit, closeModal: closeEdit } = useModal();
   const [nova, setNova] = useState('');
   const [editar, setEditar] = useState({ id: '', nome: '' });
+  const [filtro, setFiltro] = useState('');
+  const fileInput = useRef<HTMLInputElement>(null);
 
   const handleAdd = (e: React.FormEvent) => {
     e.preventDefault();
@@ -32,12 +34,50 @@ export default function CategoriasConfigPage() {
     closeEdit();
   };
 
+  const handleExport = () => {
+    const data = JSON.stringify(categorias, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'categorias.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport: React.ChangeEventHandler<HTMLInputElement> = e => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result as string) as { nome: string }[];
+        data.forEach(d => d.nome && adicionarCategoria(d.nome));
+      } catch (err) {
+        console.error('Erro ao importar categorias', err);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const filtradas = categorias.filter(c =>
+    c.nome.toLowerCase().includes(filtro.toLowerCase())
+  );
+
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold text-gray-800">Categorias de Produtos</h1>
-      <Button onClick={openModal} variant="primary">Nova Categoria</Button>
+      <div className="flex flex-wrap items-end gap-2">
+        <Button onClick={openModal} variant="primary">Nova Categoria</Button>
+        <Button onClick={handleExport} variant="secondary">Exportar JSON</Button>
+        <Button onClick={() => fileInput.current?.click()} variant="secondary">Importar JSON</Button>
+        <div className="flex-1 min-w-[150px]">
+          <Input label="Buscar" value={filtro} onChange={e => setFiltro(e.target.value)} />
+        </div>
+      </div>
+      <input type="file" ref={fileInput} className="hidden" accept="application/json" onChange={handleImport} />
       <Table headers={["Nome", "Ações"]}>
-        {categorias.map(cat => (
+        {filtradas.map(cat => (
           <TableRow key={cat.id}>
             <TableCell>{cat.nome}</TableCell>
             <TableCell className="flex items-center space-x-2">

--- a/src/app/configuracoes/page.tsx
+++ b/src/app/configuracoes/page.tsx
@@ -5,32 +5,40 @@ export default function ConfiguracoesPage() {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold text-gray-800">Configurações</h1>
-      <div className="space-y-2">
-        <Link
-          href="/configuracoes/usuarios"
-          className="inline-flex items-center justify-center rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 bg-[var(--cor-acao)] text-white hover:brightness-90 focus:ring-[var(--cor-acao)] px-4 py-2"
-        >
-          Controle de Usuários
-        </Link>
-        <Link
-          href="/configuracoes/categorias"
-          className="inline-flex items-center justify-center rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 bg-[var(--cor-acao)] text-white hover:brightness-90 focus:ring-[var(--cor-acao)] px-4 py-2"
-        >
-          Categorias de Produtos
-        </Link>
-        <Link
-          href="/configuracoes/categorias-receitas"
-          className="inline-flex items-center justify-center rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 bg-[var(--cor-acao)] text-white hover:brightness-90 focus:ring-[var(--cor-acao)] px-4 py-2"
-        >
-          Categorias de Receitas
-        </Link>
-        <Link
-          href="/configuracoes/unidades"
-          className="inline-flex items-center justify-center rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 bg-[var(--cor-acao)] text-white hover:brightness-90 focus:ring-[var(--cor-acao)] px-4 py-2"
-        >
-          Unidades de Medida
-        </Link>
-      </div>
+      <ul className="space-y-2">
+        <li>
+          <Link
+            href="/configuracoes/usuarios"
+            className="block rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 bg-[var(--cor-acao)] text-white hover:brightness-90 focus:ring-[var(--cor-acao)] px-4 py-2"
+          >
+            Controle de Usuários
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/configuracoes/categorias"
+            className="block rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 bg-[var(--cor-acao)] text-white hover:brightness-90 focus:ring-[var(--cor-acao)] px-4 py-2"
+          >
+            Categorias de Produtos
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/configuracoes/categorias-receitas"
+            className="block rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 bg-[var(--cor-acao)] text-white hover:brightness-90 focus:ring-[var(--cor-acao)] px-4 py-2"
+          >
+            Categorias de Receitas
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/configuracoes/unidades"
+            className="block rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 bg-[var(--cor-acao)] text-white hover:brightness-90 focus:ring-[var(--cor-acao)] px-4 py-2"
+          >
+            Unidades de Medida
+          </Link>
+        </li>
+      </ul>
     </div>
   );
 }

--- a/src/app/configuracoes/perfil/page.tsx
+++ b/src/app/configuracoes/perfil/page.tsx
@@ -1,14 +1,29 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Input from '@/components/ui/Input';
 import Button from '@/components/ui/Button';
+import Toast from '@/components/ui/Toast';
 import { useUsuarios } from '@/lib/usuariosService';
 
 export default function PerfilPage() {
-  const { usuarioAtual, alterarSenha } = useUsuarios();
+  const { usuarioAtual, alterarSenha, editarUsuario } = useUsuarios();
+  const [perfilForm, setPerfilForm] = useState({ nome: '', email: '', role: 'viewer' as 'admin' | 'editor' | 'viewer' });
   const [senhaForm, setSenhaForm] = useState({ senha: '', confirmar: '' });
   const [erro, setErro] = useState('');
+  const [toast, setToast] = useState('');
+
+  useEffect(() => {
+    if (usuarioAtual) {
+      setPerfilForm({ nome: usuarioAtual.nome, email: usuarioAtual.email, role: usuarioAtual.role });
+    }
+  }, [usuarioAtual]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   if (!usuarioAtual) return <p className="p-4">Nenhum usuário logado.</p>;
 
@@ -21,19 +36,42 @@ export default function PerfilPage() {
     alterarSenha(usuarioAtual.id, senhaForm.senha);
     setSenhaForm({ senha: '', confirmar: '' });
     setErro('');
-    alert('Senha alterada');
+    setToast('Senha alterada');
+  };
+
+  const handlePerfil = (e: React.FormEvent) => {
+    e.preventDefault();
+    const ok = editarUsuario(usuarioAtual.id, perfilForm);
+    if (ok) {
+      setToast('Perfil atualizado');
+    } else {
+      setErro('Email já cadastrado');
+    }
   };
 
   return (
     <div className="space-y-4">
+      <Toast message={toast} onClose={() => setToast('')} />
       <h1 className="text-2xl font-bold text-gray-800">Perfil</h1>
-      <div className="space-y-2">
-        <p><strong>Nome:</strong> {usuarioAtual.nome}</p>
-        <p><strong>Email:</strong> {usuarioAtual.email}</p>
-        <p><strong>Perfil:</strong> {usuarioAtual.role === 'admin' ? 'Administrador' : 'Visualizador'}</p>
-      </div>
-      <form onSubmit={handleSenha} className="space-y-2 max-w-sm">
+      <form onSubmit={handlePerfil} className="space-y-2 max-w-sm">
+        <Input label="Nome" value={perfilForm.nome} onChange={e => setPerfilForm({ ...perfilForm, nome: e.target.value })} required />
+        <Input label="Email" type="email" value={perfilForm.email} onChange={e => setPerfilForm({ ...perfilForm, email: e.target.value })} required />
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Perfil</label>
+          <select
+            value={perfilForm.role}
+            onChange={e => setPerfilForm({ ...perfilForm, role: e.target.value as 'admin' | 'editor' | 'viewer' })}
+            className="border border-[var(--cor-borda)] rounded-md p-2 w-full"
+          >
+            <option value="viewer">Visualizador</option>
+            <option value="editor">Editor</option>
+            <option value="admin">Administrador</option>
+          </select>
+        </div>
         {erro && <p className="text-sm text-red-600">{erro}</p>}
+        <Button type="submit" variant="primary">Salvar Perfil</Button>
+      </form>
+      <form onSubmit={handleSenha} className="space-y-2 max-w-sm">
         <Input label="Nova Senha" type="password" value={senhaForm.senha} onChange={e => setSenhaForm({ ...senhaForm, senha: e.target.value })} required />
         <Input label="Confirmar Senha" type="password" value={senhaForm.confirmar} onChange={e => setSenhaForm({ ...senhaForm, confirmar: e.target.value })} required />
         <Button type="submit" variant="primary">Alterar Senha</Button>

--- a/src/app/fichas-tecnicas/[id]/editar/page.tsx
+++ b/src/app/fichas-tecnicas/[id]/editar/page.tsx
@@ -14,6 +14,7 @@ import { useUnidadesMedida } from '@/lib/unidadesService';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 import { useModal } from '@/components/ui/Modal';
 import Modal from '@/components/ui/Modal';
+import Toast from '@/components/ui/Toast';
 
 type Ingrediente = Omit<IngredienteFicha, 'id' | 'custo'>;
 
@@ -41,6 +42,7 @@ export default function EditarFichaTecnicaPage() {
   const { unidades } = useUnidadesMedida();
   const { categorias } = useCategoriasReceita();
   const [isSaving, setIsSaving] = useState(false);
+  const [toast, setToast] = useState('');
   
   const fichaId = params.id as string;
   const fichaOriginal = obterFichaTecnicaPorId(fichaId);
@@ -79,6 +81,12 @@ export default function EditarFichaTecnicaPage() {
   });
 
   const [erros, setErros] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   useEffect(() => {
     if (!fichaTecnica.unidadeRendimento) return;
@@ -255,7 +263,7 @@ export default function EditarFichaTecnicaPage() {
       router.push(`/fichas-tecnicas/${fichaId}`);
     } catch (error) {
       console.error('Erro ao atualizar ficha técnica:', error);
-      alert('Ocorreu um erro ao atualizar a ficha técnica. Tente novamente.');
+      setToast('Erro ao atualizar ficha técnica');
     } finally {
       setIsSaving(false);
     }
@@ -275,6 +283,7 @@ export default function EditarFichaTecnicaPage() {
 
   return (
     <div className="space-y-6">
+      <Toast message={toast} onClose={() => setToast('')} />
       <h1 className="text-2xl font-bold text-gray-800">Editar Ficha Técnica</h1>
       
       <form onSubmit={handleSubmit}>

--- a/src/app/fichas-tecnicas/nova/page.tsx
+++ b/src/app/fichas-tecnicas/nova/page.tsx
@@ -14,6 +14,7 @@ import { useUnidadesMedida } from '@/lib/unidadesService';
 import Table, { TableRow, TableCell } from '@/components/ui/Table';
 import { useModal } from '@/components/ui/Modal';
 import Modal from '@/components/ui/Modal';
+import Toast from '@/components/ui/Toast';
 
 type Ingrediente = Omit<IngredienteFicha, 'id' | 'custo'>;
 
@@ -36,6 +37,7 @@ export default function NovaFichaTecnicaPage() {
   const { unidades } = useUnidadesMedida();
   const { categorias } = useCategoriasReceita();
   const [isLoading, setIsLoading] = useState(false);
+  const [toast, setToast] = useState('');
 
   
   // Modal para adicionar ingredientes
@@ -78,6 +80,12 @@ export default function NovaFichaTecnicaPage() {
   }, [fichaTecnica.ingredientes, fichaTecnica.unidadeRendimento]);
 
   const [erros, setErros] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   // Manipular mudanças nos campos da ficha técnica
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
@@ -210,7 +218,7 @@ export default function NovaFichaTecnicaPage() {
       router.push('/fichas-tecnicas');
     } catch (error) {
       console.error('Erro ao salvar ficha técnica:', error);
-      alert('Ocorreu um erro ao salvar a ficha técnica. Tente novamente.');
+      setToast('Erro ao salvar ficha técnica');
     } finally {
       setIsLoading(false);
     }
@@ -230,6 +238,7 @@ export default function NovaFichaTecnicaPage() {
 
   return (
     <div className="space-y-6">
+      <Toast message={toast} onClose={() => setToast('')} />
       <h1 className="text-2xl font-bold text-gray-800">Nova Ficha Técnica</h1>
       
       <form onSubmit={handleSubmit}>

--- a/src/app/produtos/[id]/editar/page.tsx
+++ b/src/app/produtos/[id]/editar/page.tsx
@@ -9,6 +9,7 @@ import Button from '@/components/ui/Button';
 import { useProdutos } from '@/lib/produtosService';
 import { useUnidadesMedida } from '@/lib/unidadesService';
 import { useCategorias } from '@/lib/categoriasService';
+import Toast from '@/components/ui/Toast';
 
 export default function EditarInsumoPage() {
   const params = useParams();
@@ -18,6 +19,13 @@ export default function EditarInsumoPage() {
   const { unidades } = useUnidadesMedida();
   const [isLoading, setIsLoading] = useState(false);
   const [mostrarInfoNutricional, setMostrarInfoNutricional] = useState(false);
+  const [toast, setToast] = useState('');
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
   
   const produtoId = params.id as string;
   
@@ -171,7 +179,7 @@ export default function EditarInsumoPage() {
       router.push(`/produtos/${produtoId}`);
     } catch (error) {
       console.error('Erro ao atualizar produto:', error);
-      alert('Ocorreu um erro ao atualizar o produto. Tente novamente.');
+      setToast('Erro ao atualizar produto');
     } finally {
       setIsLoading(false);
     }
@@ -179,6 +187,7 @@ export default function EditarInsumoPage() {
 
   return (
     <div className="space-y-6">
+      <Toast message={toast} onClose={() => setToast('')} />
       <h1 className="text-2xl font-bold text-gray-800">Editar Insumo</h1>
       
       <form onSubmit={handleSubmit}>

--- a/src/app/produtos/novo/page.tsx
+++ b/src/app/produtos/novo/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Card from '@/components/ui/Card';
 import Input from '@/components/ui/Input';
@@ -9,7 +9,7 @@ import Button from '@/components/ui/Button';
 import { useProdutos } from '@/lib/produtosService';
 import { useUnidadesMedida } from '@/lib/unidadesService';
 import { useCategorias } from '@/lib/categoriasService';
-import { useState } from 'react';
+import Toast from '@/components/ui/Toast';
 
 export default function NovoInsumoPage() {
   const router = useRouter();
@@ -18,6 +18,13 @@ export default function NovoInsumoPage() {
   const { unidades } = useUnidadesMedida();
   const [isLoading, setIsLoading] = useState(false);
   const [mostrarInfoNutricional, setMostrarInfoNutricional] = useState(false);
+  const [toast, setToast] = useState('');
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
   
   const [produto, setProduto] = useState({
     nome: '',
@@ -135,7 +142,7 @@ export default function NovoInsumoPage() {
       router.push('/produtos');
     } catch (error) {
       console.error('Erro ao salvar produto:', error);
-      alert('Ocorreu um erro ao salvar o produto. Tente novamente.');
+      setToast('Erro ao salvar produto');
     } finally {
       setIsLoading(false);
     }
@@ -143,6 +150,7 @@ export default function NovoInsumoPage() {
 
   return (
     <div className="space-y-6">
+      <Toast message={toast} onClose={() => setToast('')} />
       <h1 className="text-2xl font-bold text-gray-800">Novo Insumo</h1>
       
       <form onSubmit={handleSubmit}>

--- a/src/app/usuarios/novo/page.tsx
+++ b/src/app/usuarios/novo/page.tsx
@@ -11,10 +11,10 @@ import Logo from '@/components/ui/Logo';
 export default function NovoUsuarioPage() {
   const router = useRouter();
   const { registrarUsuario } = useUsuarios();
-  const [form, setForm] = useState({ nome: '', email: '', senha: '', confirmarSenha: '' });
+  const [form, setForm] = useState({ nome: '', email: '', senha: '', confirmarSenha: '', role: 'viewer' });
   const [erro, setErro] = useState('');
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
@@ -24,7 +24,11 @@ export default function NovoUsuarioPage() {
       setErro('Senhas não conferem');
       return;
     }
-    registrarUsuario({ nome: form.nome, email: form.email, senha: form.senha, role: 'viewer' });
+    const criado = registrarUsuario({ nome: form.nome, email: form.email, senha: form.senha, role: form.role as 'admin' | 'editor' | 'viewer' });
+    if (!criado) {
+      setErro('Email já cadastrado ou senha fraca');
+      return;
+    }
     router.push('/login');
   };
 
@@ -41,6 +45,19 @@ export default function NovoUsuarioPage() {
           <Input label="Email" type="email" name="email" value={form.email} onChange={handleChange} required />
           <Input label="Senha" type="password" name="senha" value={form.senha} onChange={handleChange} required />
           <Input label="Confirmar Senha" type="password" name="confirmarSenha" value={form.confirmarSenha} onChange={handleChange} required />
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Perfil</label>
+            <select
+              name="role"
+              value={form.role}
+              onChange={handleChange}
+              className="border border-[var(--cor-borda)] rounded-md p-2 w-full"
+            >
+              <option value="viewer">Visualizador</option>
+              <option value="editor">Editor</option>
+              <option value="admin">Administrador</option>
+            </select>
+          </div>
           <Button type="submit" variant="primary" fullWidth>Cadastrar</Button>
         </form>
       </Card>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,7 +21,7 @@ const Header: React.FC = () => {
         </div>
 
         <div className="flex items-center space-x-4">
-          <div className="relative">
+          <div className="relative" onMouseLeave={() => setIsProfileOpen(false)}>
             <button 
               onClick={toggleProfile}
               className="flex items-center space-x-2 focus:outline-none"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -17,7 +17,7 @@ const Sidebar: React.FC = () => {
       style={{ backgroundColor: 'var(--cor-primaria)' }}
     >
       <div className="p-4 flex items-center justify-between">
-        {!isCollapsed && <Logo className="text-xl" />}
+        {!isCollapsed && <Logo className="text-xl" showTagline />}
         <button
           onClick={toggleSidebar}
           className="p-1 rounded-full hover:bg-[var(--cor-secundaria)]"

--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -1,10 +1,18 @@
 import Image from 'next/image';
 import React from 'react';
 
-const Logo: React.FC<{className?: string}> = ({ className = '' }) => (
+interface LogoProps {
+  className?: string;
+  showTagline?: boolean;
+}
+
+const Logo: React.FC<LogoProps> = ({ className = '', showTagline = false }) => (
   <span className={`inline-flex items-center space-x-2 ${className}`}>
-    <Image src="/logo.svg" alt="CustoChef" width={24} height={24} />
-    <span className="font-bold">CustoChef</span>
+    <Image src="/logo.svg" alt="GastroChef" width={24} height={24} />
+    <span className="font-bold">GastroChef</span>
+    {showTagline && (
+      <span className="text-xs whitespace-nowrap">Sistema de Fichas Técnicas</span>
+    )}
   </span>
 );
 


### PR DESCRIPTION
## Summary
- allow editing users with new `editarUsuario` helper
- show tagline in sidebar logo
- hide profile menu on mouse leave
- render configuration links as a list
- support editing own profile details

## Testing
- `npm install` *(failed: network or permissions)*
- `npm run lint` *(failed: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b19b90c50832195af0d176366f85a